### PR TITLE
Reoptjl fixes

### DIFF
--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -566,29 +566,6 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
 					p.DemandLookbackPercent * dvPeakDemandELookback )
 	end
 	### End Constraint Set (12)
-		
-	### Constraint (13): Annual minimum charge adder 
-	if p.AnnualMinCharge > 12 * p.MonthlyMinCharge
-        TotalMinCharge = p.AnnualMinCharge 
-    else
-        TotalMinCharge = 12 * p.MonthlyMinCharge
-    end
-	
-	if TotalMinCharge >= 1e-2
-        @constraint(REopt, MinChargeAddCon, MinChargeAdder >= TotalMinCharge - (
-			#Demand Charges
-			p.TimeStepScaling * sum( p.ElecRate[u,ts] * dvGridPurchase[u,ts] for ts in p.TimeStep, u in p.PricingTier ) +
-			#Peak Ratchet Charges
-			sum( p.DemandRates[r,e] * dvPeakDemandE[r,e] for r in p.Ratchets, e in p.DemandBin) + 
-			#Preak Monthly Demand Charges
-			sum( p.DemandRatesMonth[m,n] * dvPeakDemandEMonth[m,n] for m in p.Month, n in p.DemandMonthsBin) -
-			# Energy Exports
-			p.TimeStepScaling * sum( sum(p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) + sum(p.GridExportRates[u,ts] * dvProductionToGrid[t,u,ts] for u in p.SalesTiers, t in p.TechsBySalesTier[u]) for ts in p.TimeStep ) - 
-			p.FixedMonthlyCharge * 12 )
-		)
-	else
-		@constraint(REopt, MinChargeAddCon, MinChargeAdder == 0)
-    end
 	
 	### Alternate constraint (13): Monthly minimum charge adder
 	
@@ -665,6 +642,21 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
     @expression(REopt, DemandFlatCharges, p.pwf_e * sum( p.DemandRatesMonth[m,n] * dvPeakDemandEMonth[m,n] for m in p.Month, n in p.DemandMonthsBin) )
     @expression(REopt, TotalDemandCharges, DemandTOUCharges + DemandFlatCharges)
     TotalFixedCharges = p.pwf_e * p.FixedMonthlyCharge * 12
+		
+	### Constraint (13): Annual minimum charge adder 
+	if p.AnnualMinCharge > 12 * p.MonthlyMinCharge
+        TotalMinCharge = p.AnnualMinCharge 
+    else
+        TotalMinCharge = 12 * p.MonthlyMinCharge
+    end
+	
+	if TotalMinCharge >= 1e-2
+        @constraint(REopt, MinChargeAddCon, MinChargeAdder >= TotalMinCharge - ( 
+			TotalEnergyChargesUtil + TotalDemandCharges + TotalExportBenefit + TotalFixedCharges)
+		)
+	else
+		@constraint(REopt, MinChargeAddCon, MinChargeAdder == 0)
+    end
 	
 	###  New Objective Function
 	@expression(REopt, REcosts,

--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -624,10 +624,11 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
 
 	### Utility and Taxable Costs
 	if !isempty(p.Tech)
-		@expression(REopt, TotalExportBenefit, -1 *p.pwf_e * p.TimeStepScaling * sum( 
+		@expression(REopt, TotalExportBenefit, p.pwf_e * p.TimeStepScaling * sum( 
 			sum(p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) 
-			+ sum(p.GridExportRates[u,ts] * dvProductionToGrid[t,u,ts] for u in p.SalesTiers, t in p.TechsBySalesTier[u]) 
-			for ts in p.TimeStep ) 
+			+ sum(p.GridExportRates[u,ts] * dvProductionToGrid[t,u,ts] 
+				  for u in p.SalesTiers, t in p.TechsBySalesTier[u]
+			) for ts in p.TimeStep )
 		)
 		@expression(REopt, TotalProductionIncentive, sum(dvProdIncent[t] for t in p.Tech))
 
@@ -639,7 +640,12 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
 						for t in GeneratorTechs, u in p.SalesTiersByTech[t], ts in p.TimeStep))        
 		# Needs levelization factor?
 		@expression(REopt, ExportBenefitYr1,
-				p.TimeStepScaling * sum( sum( p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) + sum(dvProductionToGrid[t,u,ts] for u in p.SalesTiers, t in p.TechsBySalesTier[u]) for ts in p.TimeStep ) )
+				p.TimeStepScaling * sum( 
+				sum( p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) 
+				+ sum( p.GridExportRates[u,ts] * dvProductionToGrid[t,u,ts] 
+					  for u in p.SalesTiers, t in p.TechsBySalesTier[u]) 
+				for ts in p.TimeStep ) 
+		)
 	else
 		@expression(REopt, TotalExportBenefit, 0.0)
 		@expression(REopt, TotalProductionIncentive, 0.0)

--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -601,6 +601,7 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
 
 	### Utility and Taxable Costs
 	if !isempty(p.Tech)
+		# NOTE: LevelizationFactor is baked into dvProductionToGrid
 		@expression(REopt, TotalExportBenefit, p.pwf_e * p.TimeStepScaling * sum( 
 			sum(p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) 
 			+ sum(p.GridExportRates[u,ts] * dvProductionToGrid[t,u,ts] 
@@ -611,11 +612,12 @@ function reopt_run(reo_model, MAXTIME::Int64, p::Parameter)
 
 		@expression(REopt, ExportedElecWIND,
 					p.TimeStepScaling * sum(dvProductionToGrid[t,u,ts] 
-						for t in WindTechs, u in p.SalesTiersByTech[t], ts in p.TimeStep))
+						for t in WindTechs, u in p.SalesTiersByTech[t], ts in p.TimeStep)
+		)
 		@expression(REopt, ExportedElecGEN,
 					p.TimeStepScaling * sum(dvProductionToGrid[t,u,ts] 
-						for t in GeneratorTechs, u in p.SalesTiersByTech[t], ts in p.TimeStep))        
-		# Needs levelization factor?
+						for t in GeneratorTechs, u in p.SalesTiersByTech[t], ts in p.TimeStep)
+		)        
 		@expression(REopt, ExportBenefitYr1,
 				p.TimeStepScaling * sum( 
 				sum( p.GridExportRates[u,ts] * dvStorageToGrid[u,ts] for u in p.StorageSalesTiers) 

--- a/reo/src/urdb_parse.py
+++ b/reo/src/urdb_parse.py
@@ -495,9 +495,9 @@ class UrdbParse:
         if len(techs) > 0:
             num_sales_tiers = 3
             techs_by_rate = [list(), list(), list()]
-            grid_export_rates = operator.add(grid_export_rates, positive_energy_costs)
-            grid_export_rates = operator.add(grid_export_rates, wholesale_rate_costs)
-            grid_export_rates = operator.add(grid_export_rates, excess_rate_costs)
+            grid_export_rates = operator.add(grid_export_rates, negative_energy_costs)
+            grid_export_rates = operator.add(grid_export_rates, negative_wholesale_rate_costs)
+            grid_export_rates = operator.add(grid_export_rates, negative_excess_rate_costs)
         else: 
             num_sales_tiers = 0
             techs_by_rate = []


### PR DESCRIPTION
- reverted export rate inputs to negative values (to match legacy conventions)
- MinChargeAdd in reopt.jl was only accounting for year zero charges (needs to be lifecycle charges)
- clarified LevelizationFactor accounting in ExportBenefits