### PR TITLE
Resil endpoint fixes

### DIFF
--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -111,7 +111,10 @@ class OutageSimJob(ModelResource):
 def run_outage_sim_task(run_uuid, bau):
         scenario = ScenarioModel.objects.get(run_uuid=run_uuid)
         results = run_outage_sim(run_uuid, with_tech=True, bau=bau)
-        rm = ResilienceModel.create(scenariomodel=scenario)
+        try:  # See if this is a duplicate POST for the given run_uuid
+            rm = ResilienceModel.objects.get(scenariomodel=scenario)
+        except ResilienceModel.DoesNotExist:  # No. This is the first POST for this run_uuid
+            rm = ResilienceModel.create(scenariomodel=scenario)
 
         try:
             ResilienceModel.objects.filter(id=rm.id).update(**results)

--- a/resilience_stats/tests/test_new_post_endpoint.py
+++ b/resilience_stats/tests/test_new_post_endpoint.py
@@ -70,7 +70,7 @@ class OutageSimTests(ResourceTestCaseMixin, TestCase):
         run_uuid = r_opt.get('run_uuid')
 
         assert(run_uuid is not None)
-        post_sim = {"run_uuid": run_uuid, "bau": False}
+        post_sim = {"run_uuid": run_uuid, "bau": True}
         resp = self.get_response_sim(data_sim=post_sim)
         self.assertHttpCreated(resp)
         r_sim = json.loads(resp.content)

--- a/resilience_stats/views.py
+++ b/resilience_stats/views.py
@@ -93,12 +93,13 @@ def resilience_stats(request: Union[Dict, HttpRequest], run_uuid=None):
         try:  # catch specific exception
             rm = ResilienceModel.objects.get(scenariomodel=scenario)
         except ResilienceModel.DoesNotExist:  # case for no resilience_stats generated yet
-            msg = "Outage sim results are not ready. "
-            msg += (
-                "If you have already submitted an outagesimjob, please try again later. If not, please first submit an outagesimjob by sending a POST request to /outagesimjob/ with the run_uuid and bau data to generate the" \
-                " outage simulation results before GET-ing the results from /resilience_stats endpoint. ")
-            sample_payload = {"run_uuid": "6ea30f0f-3723-4fd1-8a3f-bebf8a3e4dbf", "bau": False}
-            msg += "Sample body data for POST-ing to /outagesimjob/: " + json.dumps(sample_payload)
+            msg = ('Outage sim results are not ready. '
+                'If you have already submitted an outagesimjob, please try again later. '
+                'If not, please first submit an outagesimjob by sending a POST request to '
+                'v1/outagesimjob/ with run_uuid and bau parameters. This will generate'
+                ' outage simulation results that you can access from a GET request to the '
+                'v1/job/<run uuid>/resilience_stats endpoint. ')
+            msg += 'Sample body data for POST-ing to /outagesimjob/: {"run_uuid\": \"6ea30f0f-3723-4fd1-8a3f-bebf8a3e4dbf\", \"bau\": false}' 
             return JsonResponse({"Error": msg}, content_type='application/json', status=404)
 
         else:  # ResilienceModel does exist
@@ -118,7 +119,10 @@ def resilience_stats(request: Union[Dict, HttpRequest], run_uuid=None):
                 results = filtered_dict
 
         results.update({
-            "help_text": "The present_worth_factor and avg_critical_load are provided such that one can calculate an avoided outage cost in dollars by multiplying a value of load load ($/kWh) times the avg_critical_load, resilience_hours_avg, and present_worth_factor. Note that if the outage event is 'major', i.e. only occurs once, then the present_worth_factor is 1."
+            "help_text": ("The present_worth_factor and avg_critical_load are provided such"
+                " that one can calculate an avoided outage cost in dollars by multiplying a value "
+                "of load load ($/kWh) by the avg_critical_load, resilience_hours_avg, and present_worth_factor."
+                " Note that if the outage event is 'major' (i.e. only occurs once), then the present_worth_factor is 1.")
         })
         response = JsonResponse({"outage_sim_results": results}, content_type='application/json', status=200)
         return response


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature - return a descriptive error msg to the user when the resilience_stats POST end-point is hit more than once using the same run_uuid || bug - raise the error properly


* **What is the current behavior?** (You can also link to an open issue here)
The code tries to create more than one ResilienceModel for the same run_uuid, prompting database to error out. 



* **What is the new behavior (if this is a feature change)?**
When a duplicate POST (i.e. a post with same run_uuid that has been sent earlier) comes in, it catches the problem in a try block by checking for the ResilienceModel and sends an error message back. 



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
