### PR TITLE
Workaround for DimensionMismatch time out bug

### DIFF
--- a/reo/src/run_jump_model.py
+++ b/reo/src/run_jump_model.py
@@ -193,6 +193,10 @@ def run_jump_model(self, dfm, data, run_uuid, bau=False):
     except Exception as e:
         if isinstance(e, REoptFailedToStartError):
             raise e
+        elif "DimensionMismatch" in e.args[0]:  # bug in Xpress.jl and/or JuMP that mishandles timeouts
+            msg = "Optimization exceeded timeout: {} seconds.".format(data["inputs"]["Scenario"]["timeout_seconds"])
+            logger.info(msg)
+            raise OptimizationTimeout(task=name, message=msg, run_uuid=self.run_uuid, user_uuid=self.user_uuid)
         exc_type, exc_value, exc_traceback = sys.exc_info()
         print(exc_type)
         print(exc_value)


### PR DESCRIPTION
## Bug fix
Optimization timeouts lead to an exception from JuMP when a mosel model times out. This change now raises the existing `OptimizationTimeout` Exception class to appropriately handle the error.