### PR TITLE
Increase Julia threads to 2

### DIFF
--- a/config/deploy/templates/foreman/env.erb
+++ b/config/deploy/templates/foreman/env.erb
@@ -10,3 +10,4 @@ LD_PRELOAD=/usr/local/julia-1.3.1/lib/julia/libstdc++.so.6
 SOLVER=xpress
 XPRESSDIR=/opt/xpressmp
 JULIA_PROJECT="<%= current_path %>/julia_envs/Xpress"
+JULIA_NUM_THREADS=2


### PR DESCRIPTION
@Bill-Becker @t-kwasnik I'm testing this out on c110p now using a CHP scenario on chpbeta branch. Note that this in effect determines how many cores each celery worker can use because the celery workers' most computationally intensive task is solving the JuMP model.  We should try it out with more threads once the `parallelsubproblems` branch is ready for deployment. Keep in mind each server has 16 cores and we can't control how many jobs are POST'ed at a time - so we probably should be conservative with the settings.  @zolanaj as you are testing locally you could increase your JULIA_NUM_THREADS too (maybe you already have). @t-kwasnik this could be something to evaluate in your benchmarking as well.

Note that this change will set the value for any server that gets this change deployed to it. If we need to we could set server specific JULIA_NUM_THREADS as well.