### PR TITLE
Fix curtailment and wind-to-battery tracking

### DIFF
--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -93,9 +93,13 @@ function add_export_expressions(m, p)
 				  for u in p.SalesTiers, t in p.TechsBySalesTier[u]
 			) for ts in p.TimeStep )
 		)
+		m[:CurtailedElecWIND] = @expression(m,
+			p.TimeStepScaling * sum(m[:dvProductionToGrid][t,u,ts] 
+				for t in m[:WindTechs], u in p.CurtailmentTiers, ts in p.TimeStep)
+		)
 		m[:ExportedElecWIND] = @expression(m,
 			p.TimeStepScaling * sum(m[:dvProductionToGrid][t,u,ts] 
-				for t in m[:WindTechs], u in p.SalesTiersByTech[t], ts in p.TimeStep)
+				for t in m[:WindTechs], u in p.SalesTiersByTech[t], ts in p.TimeStep) - m[:CurtailedElecWIND]
 		)
 		m[:ExportedElecGEN] = @expression(m,
 			p.TimeStepScaling * sum(m[:dvProductionToGrid][t,u,ts] 
@@ -110,6 +114,7 @@ function add_export_expressions(m, p)
 		)
 	else
 		m[:TotalExportBenefit] = 0
+		m[:CurtailedElecWIND] = 0
 		m[:ExportedElecWIND] = 0
 		m[:ExportedElecGEN] = 0
 		m[:ExportBenefitYr1] = 0
@@ -1059,6 +1064,7 @@ function add_util_results(m, p, r::Dict)
 						 "total_min_charge_adder" => round(value(m[:MinChargeAdder]) * m[:r_tax_fraction_offtaker], digits=2),
 						 "net_capital_costs_plus_om" => round(net_capital_costs_plus_om, digits=0),
 						 "average_annual_energy_exported_wind" => round(value(m[:ExportedElecWIND]), digits=0),
+						 "average_annual_energy_curtailed_wind" => round(value(m[:CurtailedElecWIND]), digits=0),
                          "average_annual_energy_exported_gen" => round(value(m[:ExportedElecGEN]), digits=0),
 						 "net_capital_costs" => round(value(m[:TotalTechCapCosts] + m[:TotalStorageCapCosts]), digits=2))...)
 

--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -189,7 +189,7 @@ function add_bigM_adjustments(m, p)
 		end
 	end
 	
-	# NewMaxSize generates a new maximum size that is equal to the largest monthly load of the year.  This is intended to be a reasonable upper bound on size that would never be exceeeded, but is sufficienctly small to replace much larger big-M values placed as a default.
+	# NewMaxSize generates a new maximum size that is equal to the largest monthly load of the year.  This is intended to be a reasonable upper bound on size that would never be exceeeded, but is sufficiently small to replace much larger big-M values placed as a default.
 	TempHeatingTechs = [] #temporarily replace p.HeatingTechs which is undefined
 	TempCoolingTechs = [] #temporarily replace p.CoolingTechs which is undefined
 	
@@ -329,7 +329,7 @@ function add_storage_op_constraints(m, p)
 	)
 	# Constraint (4e): Electrical production sent to storage or grid must be less than technology's rated production - no grid
 	@constraint(m, ElecTechProductionFlowNoGridCon[b in p.ElecStorage, t in p.ElectricTechs, ts in p.TimeStepsWithoutGrid],
-		m[:dvProductionToStorage][b,t,ts]  <= 
+		m[:dvProductionToStorage][b,t,ts] + sum(m[:dvProductionToGrid][t,u,ts] for u in p.CurtailmentTiers)  <= 
 		p.ProductionFactor[t,ts] * p.LevelizationFactor[t] * m[:dvRatedProduction][t,ts]
 	)
 	# Constraint (4f)-1: (Hot) Thermal production sent to storage or grid must be less than technology's rated production

--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -962,12 +962,15 @@ function add_wind_results(m, p, r::Dict)
 	@expression(m, WINDtoBatt[ts in p.TimeStep],
 	            sum(sum(m[:dvProductionToStorage][b, t, ts] for t in m[:WindTechs]) for b in p.ElecStorage))
 	r["WINDtoBatt"] = round.(value.(WINDtoBatt), digits=3)
+	@expression(m, WINDtoCurtail[ts in p.TimeStep],
+				sum(m[:dvProductionToGrid][t,u,ts] for t in m[:WindTechs], u in p.CurtailmentTiers))
+	r["WINDtoCurtail"] = round.(value.(WINDtoCurtail), digits=3)
 	@expression(m, WINDtoGrid[ts in p.TimeStep],
-				sum(m[:dvProductionToGrid][t,u,ts] for t in m[:WindTechs], u in p.SalesTiers))
+				sum(m[:dvProductionToGrid][t,u,ts] for t in m[:WindTechs], u in p.SalesTiersByTech[t]) - WINDtoCurtail[ts])
 	r["WINDtoGrid"] = round.(value.(WINDtoGrid), digits=3)
 	@expression(m, WINDtoLoad[ts in p.TimeStep],
 				sum(m[:dvRatedProduction][t, ts] * p.ProductionFactor[t, ts] * p.LevelizationFactor[t]
-					for t in m[:WindTechs]) - WINDtoGrid[ts] - WINDtoBatt[ts] )
+					for t in m[:WindTechs]) - WINDtoGrid[ts] - WINDtoBatt[ts] - WINDtoCurtail[ts] )
 	r["WINDtoLoad"] = round.(value.(WINDtoLoad), digits=3)
 	m[:Year1WindProd] = @expression(m, 
 		p.TimeStepScaling * sum(m[:dvRatedProduction][t,ts] * p.ProductionFactor[t, ts] 
@@ -1001,13 +1004,17 @@ function add_pv_results(m, p, r::Dict)
             end
 			r[string(PVclass, "toBatt")] = round.(value.(PVtoBatt), digits=3)
 			
+			PVtoCurtail = @expression(m, [ts in p.TimeStep],
+					sum(m[:dvProductionToGrid][t,u,ts] for t in PVtechs_in_class, u in p.CurtailmentTiers))
+    	    r[string(PVclass, "toCurtail")] = round.(value.(PVtoCurtail), digits=3)
+			
 			PVtoGrid = @expression(m, [ts in p.TimeStep],
-					sum(m[:dvProductionToGrid][t,u,ts] for t in PVtechs_in_class, u in p.SalesTiersByTech[t]))
+					sum(m[:dvProductionToGrid][t,u,ts] for t in PVtechs_in_class, u in p.SalesTiersByTech[t]) - PVtoCurtail[ts])
     	    r[string(PVclass, "toGrid")] = round.(value.(PVtoGrid), digits=3)
 			
 			PVtoLoad = @expression(m, [ts in p.TimeStep],
 				sum(m[:dvRatedProduction][t, ts] * p.ProductionFactor[t, ts] * p.LevelizationFactor[t] for t in PVtechs_in_class) 
-				- PVtoGrid[ts] - PVtoBatt[ts]
+				- PVtoGrid[ts] - PVtoBatt[ts] - PVtoCurtail[ts]
 				)
             r[string(PVclass, "toLoad")] = round.(value.(PVtoLoad), digits=3)
 			

--- a/reo/src/reopt.jl
+++ b/reo/src/reopt.jl
@@ -959,16 +959,9 @@ end
 
 function add_wind_results(m, p, r::Dict)
 	r["wind_kw"] = round(value(sum(m[:dvSize][t] for t in m[:WindTechs])), digits=4)
-	#@expression(m, WINDtoBatt[ts in p.TimeStep],
-	#            sum(m[:dvProductionToStorage][b, t, ts] for t in m[:WindTechs], b in p.ElecStorage))
-	WINDtoBatt = 0.0*Array{Float64,1}(undef,p.TimeStepCount)
-	for ts in p.TimeStep
-		for t in m[:WindTechs]
-			for b in p.ElecStorage
-				WINDtoBatt[ts] += value(m[:dvProductionToStorage][b, t, ts]) 
-			end
-		end
-	end
+	@expression(m, WINDtoBatt[ts in p.TimeStep],
+	            sum(sum(m[:dvProductionToStorage][b, t, ts] for t in m[:WindTechs]) for b in p.ElecStorage))
+	r["WINDtoBatt"] = round.(value.(WINDtoBatt), digits=3)
 	@expression(m, WINDtoGrid[ts in p.TimeStep],
 				sum(m[:dvProductionToGrid][t,u,ts] for t in m[:WindTechs], u in p.SalesTiers))
 	r["WINDtoGrid"] = round.(value.(WINDtoGrid), digits=3)

--- a/reo/tests/posts/test_curtailment_POST.json
+++ b/reo/tests/posts/test_curtailment_POST.json
@@ -1,0 +1,30 @@
+{"Scenario": { 
+            "Site": {
+                "latitude": 41.140240,
+                "longitude": -104.818802,
+
+                "LoadProfile": {
+                    "doe_reference_name": "Hospital",
+                    "annual_kwh":500000,
+                    "outage_start_hour":2441,
+                    "outage_end_hour":2541,
+                    "critical_load_pct":0.25
+                },
+
+                "ElectricTariff": {
+                    "urdb_label": "5cb745785457a3b40a9b6ec2" 
+
+                },
+				
+				"PV": {
+					"min_kw": 1000,
+					"max_kw": 1000
+				},
+				
+				"Wind": {
+					"min_kw": 1000,
+                    "max_kw": 1000
+                }
+            }
+        }
+        }

--- a/reo/tests/posts/test_curtailment_POST.json
+++ b/reo/tests/posts/test_curtailment_POST.json
@@ -2,29 +2,99 @@
             "Site": {
                 "latitude": 41.140240,
                 "longitude": -104.818802,
+				
+				"Financial": {
+					"om_cost_escalation_pct": 0.025,
+					"escalation_pct": 0.023,
+					"offtaker_tax_pct": 0.26,
+					"offtaker_discount_pct": 0.083,
+					"two_party_ownership": false,
+					"owner_tax_pct": 0.26,
+					"owner_discount_pct": 0.083,
+					"analysis_years": 25,
+					"value_of_lost_load_us_dollars_per_kwh": 100.0,
+					"microgrid_upgrade_cost_pct": 0.3
+				},
 
                 "LoadProfile": {
                     "doe_reference_name": "Hospital",
                     "annual_kwh":500000,
+					"percent_share": 100.0,
+					"year": 2019,
+					"loads_kw_is_net": true,
+					"critical_loads_kw_is_net": false,
                     "outage_start_hour":2441,
                     "outage_end_hour":2541,
-                    "critical_load_pct":0.25
+                    "critical_load_pct":0.25,
+					"outage_is_major_event": true
                 },
 
                 "ElectricTariff": {
-                    "urdb_label": "5cb745785457a3b40a9b6ec2" 
-
+                    "urdb_label": "5cb745785457a3b40a9b6ec2",
+					"net_metering_limit_kw": 0.0,
+					"interconnection_limit_kw": 1.0e10,
+					"wholesale_rate_us_dollars_per_kwh": 0.0,
+					"wholesale_rate_above_site_load_us_dollars_per_kwh": 0.0
                 },
 				
 				"PV": {
+					"existing_kw": 0,
 					"min_kw": 1000,
-					"max_kw": 1000
+					"max_kw": 1000,
+					"installed_cost_us_dollars_per_kw": 1600.0,
+					"om_cost_us_dollars_per_kw": 16.0,
+					"macrs_option_years": 5,
+					"macrs_bonus_pct": 1,
+					"macrs_itc_reduction": 0.5,
+					"federal_itc_pct": 0.26,
+					"state_ibi_pct": 0.0,
+					"state_ibi_max_us_dollars": 1.0e10,
+					"utility_ibi_pct": 0.0,
+					"utility_ibi_max_us_dollars": 1.0e10,
+					"federal_rebate_us_dollars_per_kw": 0.0,
+					"state_rebate_us_dollars_per_kw": 0.0,
+					"state_rebate_max_us_dollars": 1.0e10,
+					"utility_rebate_us_dollars_per_kw": 0.0,
+					"utility_rebate_max_us_dollars": 1.0e10,
+					"pbi_us_dollars_per_kwh": 0.0,
+					"pbi_max_us_dollars": 1.0e9,
+					"pbi_years": 1,
+					"pbi_system_max_kw": 1.0e9,
+					"degradation_pct": 0.005,
+					"azimuth": 180,
+					"losses": 0.14,
+					"array_type": 1,
+					"module_type": 0,
+					"gcr": 0.4,
+					"dc_ac_ratio": 1.2,
+					"inv_eff": 0.96,
+					"radius": 0.0,
+					"tilt": 0.537
 				},
 				
 				"Wind": {
 					"min_kw": 1000,
-                    "max_kw": 1000
+                    "max_kw": 1000,
+					"installed_cost_us_dollars_per_kw": 3013.0,
+					"om_cost_us_dollars_per_kw": 40.0,
+					"macrs_option_years": 5,
+					"macrs_bonus_pct": 0.0,
+					"macrs_itc_reduction": 0.5,
+					"federal_itc_pct": 0.26,
+					"state_ibi_pct": 0.0,
+					"state_ibi_max_us_dollars": 1.0e10,
+					"utility_ibi_pct": 0.0,
+					"utility_ibi_max_us_dollars": 1.0e10,
+					"federal_rebate_us_dollars_per_kw": 0.0,
+					"state_rebate_us_dollars_per_kw": 0.0,
+					"state_rebate_max_us_dollars": 1.0e10,
+					"utility_rebate_us_dollars_per_kw": 0.0,
+					"utility_rebate_max_us_dollars": 1.0e10,
+					"pbi_us_dollars_per_kwh": 0.0,
+					"pbi_max_us_dollars": 1.0e9,
+					"pbi_years": 1,
+					"pbi_system_max_kw": 1.0e9
                 }
             }
         }
-        }
+	}

--- a/reo/tests/posts/test_curtailment_POST.json
+++ b/reo/tests/posts/test_curtailment_POST.json
@@ -32,7 +32,7 @@
                 "ElectricTariff": {
                     "urdb_label": "5cb745785457a3b40a9b6ec2",
 					"net_metering_limit_kw": 0.0,
-					"interconnection_limit_kw": 1.0e10,
+					"interconnection_limit_kw": 1.0e9,
 					"wholesale_rate_us_dollars_per_kwh": 0.0,
 					"wholesale_rate_above_site_load_us_dollars_per_kwh": 0.0
                 },

--- a/reo/tests/test_curtailment.py
+++ b/reo/tests/test_curtailment.py
@@ -64,8 +64,8 @@ class WindTests(ResourceTestCaseMixin, TestCase):
         d_expected = dict()
         d_expected['lcc'] = 5908025
         d_expected['npv'] = -4961719
-        d_expected['average_annual_energy_curtailed_pv'] = 996406
-        d_expected['average_annual_energy_curtailed_wind'] = 2380486
+        d_expected['average_annual_energy_curtailed_pv'] = 1015235
+        d_expected['average_annual_energy_curtailed_wind'] = 2422069
         resp = self.get_response(data=test_post)
         self.assertHttpCreated(resp)
         r = json.loads(resp.content)

--- a/reo/tests/test_curtailment.py
+++ b/reo/tests/test_curtailment.py
@@ -1,0 +1,90 @@
+# *********************************************************************************
+# REopt, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may be
+# used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+# *********************************************************************************
+import json
+import copy
+import os
+import pandas as pd
+from tastypie.test import ResourceTestCaseMixin
+from reo.nested_to_flat_output import nested_to_flat
+from django.test import TestCase  
+from reo.models import ModelManager
+from reo.utilities import check_common_outputs
+from reo.validators import ValidateNestedInput
+from reo.src.wind import WindSAMSDK, combine_wind_files
+import logging
+logging.disable(logging.CRITICAL)
+
+
+class WindTests(ResourceTestCaseMixin, TestCase):
+    REopt_tol = 1e-2
+
+    def setUp(self):
+        super(WindTests, self).setUp()
+        self.reopt_base = '/v1/job/'
+
+    def get_response(self, data):
+        return self.api_client.post(self.reopt_base, format='json', data=data)
+
+    def test_pv_curtailment(self):
+        """
+        Validation run for wind scenario with updated WindToolkit data
+        Note no tax, no ITC, no MACRS.
+        :return:
+        """
+        post_path = os.path.join('reo', 'tests', 'posts', 'test_curtailment_POST.json')
+        with open(post_path, 'r') as fp:
+            test_post = json.load(fp)
+        d_expected = dict()
+        d_expected['lcc'] = 5908025
+        d_expected['npv'] = -4961719
+        d_expected['average_annual_energy_curtailed_pv'] = 996406
+        d_expected['average_annual_energy_curtailed_wind'] = 2380486
+        resp = self.get_response(data=test_post)
+        self.assertHttpCreated(resp)
+        r = json.loads(resp.content)
+        run_uuid = r.get('run_uuid')
+        d = ModelManager.make_response(run_uuid=run_uuid)
+
+        err_messages = d['messages'].get('error') or []
+        if 'Wind Dataset Timed Out' in err_messages:
+            print("Wind Dataset Timed Out")
+        else:
+            c = nested_to_flat(d['outputs'])
+            print(d['outputs']['Scenario']['Site'].keys())
+            c['average_annual_energy_curtailed_pv'] = sum(d['outputs']['Scenario']['Site']['PV'][
+                                                               'year_one_curtailed_production_series_kw'])
+            c['average_annual_energy_curtailed_wind'] = sum(d['outputs']['Scenario']['Site']['Wind'][
+                                                               'year_one_curtailed_production_series_kw'])
+            try:
+                check_common_outputs(self, c, d_expected)
+            except:
+                print("Run {} expected outputs may have changed.".format(run_uuid))
+                print("Error message: {}".format(d['messages'].get('error')))
+                raise


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug in curtailment tracking for PV and wind technologies.


* **What is the current behavior?** (You can also link to an open issue here)
Currently curtailment is grouped together with grid sales.  In output processing, these are separated during outage periods, but it is possible to curtail outside of these hours if sales limits are met or export rates are negative.


* **What is the new behavior (if this is a feature change)?**
Curtailment is now populated separately in the JuMP results, and postprocessing has been edited to ensure separate tracking throughout the entire year..  A test has been added to ensure that curtailment takes place; in this case the system sizes are fixed to be oversized when compared to the site load so that curtailment of both wind and PV occur during the outage event. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

