### PR TITLE
Export clarifications

### DIFF
--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -248,7 +248,7 @@ class DataManager:
 
         for tech in techs:
 
-            if eval('self.' + tech) is not None and tech not in ['util']:
+            if eval('self.' + tech) is not None:
 
                 existing_kw = 0.0
                 if hasattr(eval('self.' + tech), 'existing_kw'):
@@ -568,12 +568,11 @@ class DataManager:
         """
         Many arrays are built from Tech and Load. As many as possible are defined here to reduce for-loop iterations
         :param techs: list of strings, eg. ['pv', 'pvnm']
-        :return: tech_to_load, tech_to_location, derate, eta_storage_in, eta_storage_out, \
+        :return: tech_to_location, derate, eta_storage_in, eta_storage_out, \
                om_cost_us_dollars_per_kw, om_cost_us_dollars_per_kwh, production_factor, charge_efficiency, \
                discharge_efficiency, techs_charging_storage, electric_derate
         """
         production_factor = list()
-        tech_to_load = list()
         tech_to_location = list()
         derate = list()
         electric_derate = list()
@@ -607,16 +606,6 @@ class DataManager:
                     eta_storage_in.append(self.storage.rectifier_efficiency_pct *
                                           self.storage.internal_efficiency_pct**0.5 if load == 'storage' else float(1))
 
-                    if eval('self.' + tech + '.can_serve(' + '"' + load + '"' + ')'):
-                        tech_to_load.append(1)
-                    else:
-                        tech_to_load.append(0)
-
-                    # By default, util can serve storage load.
-                    # However, if storage is being modeled it can override grid-charging
-                    if tech == 'util' and load == 'storage' and self.storage is not None:
-                        tech_to_load[-1] = int(self.storage.canGridCharge)
-
                 for location in ['roof', 'ground', 'both']:
                     if tech.startswith('pv'):
                         if eval('self.' + tech + '.location') == location:
@@ -635,7 +624,7 @@ class DataManager:
 
         # In BAU case, storage.dat must be filled out for REopt initializations, but max size is set to zero
 
-        return tech_to_load, tech_to_location, derate, eta_storage_in, eta_storage_out, \
+        return tech_to_location, derate, eta_storage_in, eta_storage_out, \
                om_cost_us_dollars_per_kw, om_cost_us_dollars_per_kwh, production_factor, charge_efficiency, \
                discharge_efficiency, electric_derate
 
@@ -814,10 +803,10 @@ class DataManager:
         tech_class_min_size, tech_to_tech_class, techs_in_class = self._get_REopt_tech_classes(self.available_techs, False)
         tech_class_min_size_bau, tech_to_tech_class_bau, techs_in_class_bau = self._get_REopt_tech_classes(self.bau_techs, True)
 
-        tech_to_load, tech_to_location, derate, eta_storage_in, eta_storage_out, om_cost_us_dollars_per_kw,\
+        tech_to_location, derate, eta_storage_in, eta_storage_out, om_cost_us_dollars_per_kw,\
             om_cost_us_dollars_per_kwh, production_factor, charge_efficiency,  \
             discharge_efficiency, electric_derate = self._get_REopt_array_tech_load(self.available_techs)
-        tech_to_load_bau, tech_to_location_bau, derate_bau, eta_storage_in_bau, eta_storage_out_bau, \
+        tech_to_location_bau, derate_bau, eta_storage_in_bau, eta_storage_out_bau, \
             om_dollars_per_kw_bau, om_dollars_per_kwh_bau, production_factor_bau, charge_efficiency_bau,  \
             discharge_efficiency_bau, electric_derate_bau = self._get_REopt_array_tech_load(self.bau_techs)
 

--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -198,7 +198,7 @@ class DataManager:
             if eval('self.' + tech) is not None:
 
 
-                if tech not in ['util', 'generator']:
+                if tech not in ['generator']:
 
                     # prod incentives don't need escalation
                     if tech.startswith("pv"):  # PV has degradation
@@ -631,17 +631,15 @@ class DataManager:
     def _get_REopt_techs(self, techs):
         reopt_techs = list()
         for tech in techs:
-
             if eval('self.' + tech) is not None:
-
-                reopt_techs.append(tech.upper() if tech is not 'util' else tech.upper() + '1')
+                reopt_techs.append(tech.upper())
 
         return reopt_techs
 
     def _get_REopt_tech_classes(self, techs, bau):
         """
 
-        :param techs: list of strings, eg. ['pv1', 'pvnm1', 'util']
+        :param techs: list of strings, eg. ['pv1', 'pvnm1']
         :return: tech_classes, tech_class_min_size, tech_to_tech_class
         """
         if len(techs) == 0:
@@ -679,7 +677,7 @@ class DataManager:
             for tech in techs:
                 if eval('self.' + tech) is not None:
                     if eval('self.' + tech + '.reopt_class').upper() == tc.upper():
-                        class_list.append(tech.upper() if tech is not 'util' else tech.upper() + '1')
+                        class_list.append(tech.upper())
             techs_in_class.append(class_list)
 
         return tech_class_min_size, tech_to_tech_class, techs_in_class

--- a/reo/src/urdb_parse.py
+++ b/reo/src/urdb_parse.py
@@ -455,6 +455,10 @@ class UrdbParse:
         else:
             negative_excess_rate_costs = [-1.0 * x for x in self.excess_rate]
 
+        if sum(negative_wholesale_rate_costs) == 0:
+            # no export to grid benefit, so force excess energy into curtailment
+            negative_wholesale_rate_costs = [100 for x in self.wholesale_rate]
+
         # FuelRate = array(Tech, FuelBin, TimeStep) is the cost of electricity from each Tech, so 0's for PV, PVNM
         energy_rates = []
         # FuelAvail: array(Tech, FuelBin)

--- a/reo/src/urdb_parse.py
+++ b/reo/src/urdb_parse.py
@@ -457,7 +457,7 @@ class UrdbParse:
 
         if sum(negative_wholesale_rate_costs) == 0:
             # no export to grid benefit, so force excess energy into curtailment
-            negative_wholesale_rate_costs = [100 for x in self.wholesale_rate]
+            negative_wholesale_rate_costs = [1000.0 for x in self.wholesale_rate]
 
         # FuelRate = array(Tech, FuelBin, TimeStep) is the cost of electricity from each Tech, so 0's for PV, PVNM
         energy_rates = []

--- a/reo/tests/test_curtailment.py
+++ b/reo/tests/test_curtailment.py
@@ -52,7 +52,7 @@ class WindTests(ResourceTestCaseMixin, TestCase):
     def get_response(self, data):
         return self.api_client.post(self.reopt_base, format='json', data=data)
 
-    def test_pv_curtailment(self):
+    def test_curtailment(self):
         """
         Validation run for wind scenario with updated WindToolkit data
         Note no tax, no ITC, no MACRS.
@@ -64,8 +64,10 @@ class WindTests(ResourceTestCaseMixin, TestCase):
         d_expected = dict()
         d_expected['lcc'] = 5908025
         d_expected['npv'] = -4961719
-        d_expected['average_annual_energy_curtailed_pv'] = 1015235
-        d_expected['average_annual_energy_curtailed_wind'] = 2422069
+        d_expected['average_annual_energy_curtailed_pv'] = 1091859
+        d_expected['average_annual_energy_curtailed_wind'] = 2841781
+        d_expected['total_pv_export'] = 0
+        d_expected['total_wind_export'] = 0
         resp = self.get_response(data=test_post)
         self.assertHttpCreated(resp)
         r = json.loads(resp.content)
@@ -79,9 +81,11 @@ class WindTests(ResourceTestCaseMixin, TestCase):
             c = nested_to_flat(d['outputs'])
             print(d['outputs']['Scenario']['Site'].keys())
             c['average_annual_energy_curtailed_pv'] = sum(d['outputs']['Scenario']['Site']['PV'][
-                                                               'year_one_curtailed_production_series_kw'])
+                                                              'year_one_curtailed_production_series_kw'])
             c['average_annual_energy_curtailed_wind'] = sum(d['outputs']['Scenario']['Site']['Wind'][
-                                                               'year_one_curtailed_production_series_kw'])
+                                                                'year_one_curtailed_production_series_kw'])
+            c['total_pv_export'] = sum(d['outputs']['Scenario']['Site']['PV']['year_one_to_grid_series_kw'])
+            c['total_wind_export'] = sum(d['outputs']['Scenario']['Site']['Wind']['year_one_to_grid_series_kw'])
             try:
                 check_common_outputs(self, c, d_expected)
             except:


### PR DESCRIPTION
# Changes to behavior
- When the wholesale rate is zero, all excess production is forced into curtailment bin by setting the wholesale rate to -1,000 $/kWh
- reo.tests.test_curtailment updated 
    - the test was not accounting for excess PV and wind that was being exported to the grid, which was an arbitrary choice since export and curtailment came at zero cost

# Minor updates
- rm obsolete tech_to_load from data_manager
- rm obsolete 'util' tech from data_manager