### PR TITLE
Chpbeta add cutstrategy solver setting

### DIFF
--- a/julia_envs/Xpress/precompile.jl
+++ b/julia_envs/Xpress/precompile.jl
@@ -19,5 +19,5 @@ Pkg.build("Xpress")
 include(joinpath(ENV["PROJECT_PATH"], "reo", "src", "reopt_xpress_model.jl"))
 include(joinpath(ENV["PROJECT_PATH"], "reo", "src", "reopt.jl"))
 
-model = reopt_model(300, 0.001)
+model = reopt_model(300, 0.001, 3)
 results = reopt(model, mi)

--- a/reo/src/reopt_decomposed.jl
+++ b/reo/src/reopt_decomposed.jl
@@ -883,7 +883,7 @@ end
 
 function add_decomp_model(m, p::Parameter, model_type::String, mth::Int64)
 	if m[:solver_name] == "Xpress"
-		sub_model = direct_model(Xpress.Optimizer(MAXTIME=-p.DecompTimeOut, MIPRELSTOP=p.DecompOptTol, OUTPUTLOG = 0))
+		sub_model = direct_model(Xpress.Optimizer(MAXTIME=-p.DecompTimeOut, MIPRELSTOP=p.DecompOptTol, CUTSTRATEGY = 3, OUTPUTLOG = 0))
 	elseif m[:solver_name] == "Cbc"
 		sub_model = Model(with_optimizer(Cbc.Optimizer, logLevel=0, seconds=p.DecompTimeOut, ratioGap=p.DecompOptTol))
 	elseif m[:solver_name] == "SCIP"

--- a/reo/src/reopt_decomposed.jl
+++ b/reo/src/reopt_decomposed.jl
@@ -883,7 +883,7 @@ end
 
 function add_decomp_model(m, p::Parameter, model_type::String, mth::Int64)
 	if m[:solver_name] == "Xpress"
-		sub_model = direct_model(Xpress.Optimizer(MAXTIME=-p.DecompTimeOut, MIPRELSTOP=p.DecompOptTol, CUTSTRATEGY = 3, OUTPUTLOG = 0))
+		sub_model = direct_model(Xpress.Optimizer(MAXTIME=-p.DecompTimeOut, MIPRELSTOP=p.DecompOptTol, CUTSTRATEGY = m[:cutstrategy], OUTPUTLOG = 0))
 	elseif m[:solver_name] == "Cbc"
 		sub_model = Model(with_optimizer(Cbc.Optimizer, logLevel=0, seconds=p.DecompTimeOut, ratioGap=p.DecompOptTol))
 	elseif m[:solver_name] == "SCIP"

--- a/reo/src/reopt_xpress_model.jl
+++ b/reo/src/reopt_xpress_model.jl
@@ -3,7 +3,7 @@ using Xpress
 
 function reopt_model(MAXTIME, MIPRELSTOP)
    
-    REopt = direct_model(Xpress.Optimizer(MAXTIME=-MAXTIME, MIPRELSTOP=MIPRELSTOP, OUTPUTLOG = 0))
+    REopt = direct_model(Xpress.Optimizer(MAXTIME=-MAXTIME, MIPRELSTOP=MIPRELSTOP, CUTSTRATEGY = 3, OUTPUTLOG = 0))
 	REopt[:solver_name] = "Xpress"
 	REopt[:timeout_seconds] = MAXTIME
 	REopt[:optimality_tolerance] = MIPRELSTOP

--- a/reo/src/reopt_xpress_model.jl
+++ b/reo/src/reopt_xpress_model.jl
@@ -1,12 +1,13 @@
 using JuMP
 using Xpress
 
-function reopt_model(MAXTIME, MIPRELSTOP)
+function reopt_model(MAXTIME, MIPRELSTOP, CUTSTRATEGY)
    
-    REopt = direct_model(Xpress.Optimizer(MAXTIME=-MAXTIME, MIPRELSTOP=MIPRELSTOP, CUTSTRATEGY = 3, OUTPUTLOG = 0))
+    REopt = direct_model(Xpress.Optimizer(MAXTIME=-MAXTIME, MIPRELSTOP=MIPRELSTOP, CUTSTRATEGY=CUTSTRATEGY, OUTPUTLOG = 0))
 	REopt[:solver_name] = "Xpress"
 	REopt[:timeout_seconds] = MAXTIME
 	REopt[:optimality_tolerance] = MIPRELSTOP
+	REopt[:cutstrategy] = CUTSTRATEGY
 	return REopt
 
 end

--- a/reo/src/run_jump_model.py
+++ b/reo/src/run_jump_model.py
@@ -136,10 +136,12 @@ def run_jump_model(self, dfm, data, run_uuid, bau=False):
             t_start = time.time()
             if bau:
                 model = Main.reopt_model(float(data["inputs"]["Scenario"]["timeout_seconds"]),
-                                         float(data["inputs"]["Scenario"]["optimality_tolerance_bau"]))
+                                         float(data["inputs"]["Scenario"]["optimality_tolerance_bau"]),
+                                         3)
             else:
                 model = Main.reopt_model(float(data["inputs"]["Scenario"]["timeout_seconds"]),
-                                         float(data["inputs"]["Scenario"]["optimality_tolerance_techs"]))
+                                         float(data["inputs"]["Scenario"]["optimality_tolerance_techs"]),
+                                         3)
             time_dict["pyjulia_make_model_seconds"] = time.time() - t_start
 
         elif os.environ.get("SOLVER") == "cbc":


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a proposed model enhancement intended to speed up the tool.  Specifically, we are evaluating a solver setting for Xpress that in preliminary tests by CSM has demonstrated improved optimality gaps for difficult instances within 5 minutes.


* **What is the current behavior?** (You can also link to an open issue here)
No open issue is addressed by this PR.


* **What is the new behavior (if this is a feature change)?**
The new solver setting will change the time required to obtain near-optimal solutions.  This is likely to exhibit improvement for more complex problems (e.g., CHP with Hot TES) but at the cost of slightly longer times for problems with fewer or non-CHP technologies.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes


* **Other information**:
@Bill-Becker @t-kwasnik if one of you are able to run the benchmarking on this and the results are available by run to obtain trends for, say, performance change as a function of the collection of technologies available or number utility tiers, that would help with a more refined policy if improvement isn't apparent at the first pass. 