### PR TITLE
updated avoided outage cost calc and decprecation message

### DIFF
--- a/reo/process_results.py
+++ b/reo/process_results.py
@@ -992,10 +992,6 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
         data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] = data['inputs']['Scenario']['Site']['LoadProfile'].get('outage_end_time_step')
         if data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] is not None:
             data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] -= 1
-        data["messages"]["warnings"]["Deprecations"] = [
-            "The sustain_hours output will be deprecated soon in favor of bau_sustained_time_steps.",
-            "outage_start_hour and outage_end_hour will be deprecated soon in favor of outage_start_time_step and outage_end_time_step",
-        ]
         profiler.profileEnd()
         data['outputs']["Scenario"]["Profile"]["parse_run_outputs_seconds"] = profiler.getDuration()
 

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -519,7 +519,7 @@ class ValidateNestedInput:
         output["Deprecations"] = [
             "The sustain_hours output will be deprecated soon in favor of bau_sustained_time_steps.",
             "outage_start_hour and outage_end_hour will be deprecated soon in favor of outage_start_time_step and outage_end_time_step",
-            "Avoided outage costs will be deprecated soon from the /results endpoint, but retained from the /resilience_stats endpoint"
+            "Avoided outage costs will be deprecated soon from the /results endpoint, but retained at the /resilience_stats endpoint"
         ]
         return output
 

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -516,6 +516,10 @@ class ValidateNestedInput:
         if bool(self.emission_warning):
             output["Emissons Warning"] = {"error":self.emission_warning}
 
+        output["Deprecations"] = [
+            "The sustain_hours output will be deprecated soon in favor of bau_sustained_time_steps.",
+            "outage_start_hour and outage_end_hour will be deprecated soon in favor of outage_start_time_step and outage_end_time_step",
+        ]
         return output
 
     def isSingularKey(self, k):

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -519,6 +519,7 @@ class ValidateNestedInput:
         output["Deprecations"] = [
             "The sustain_hours output will be deprecated soon in favor of bau_sustained_time_steps.",
             "outage_start_hour and outage_end_hour will be deprecated soon in favor of outage_start_time_step and outage_end_time_step",
+            "Avoided outage costs will be deprecated soon from the /results endpoint, but retained from the /resilience_stats endpoint"
         ]
         return output
 

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -40,7 +40,7 @@ from tastypie.serializers import Serializer
 from tastypie.validation import Validation
 
 from reo.exceptions import SaveToDatabase
-from reo.models import ScenarioModel, FinancialModel, MessageModel
+from reo.models import ScenarioModel, FinancialModel
 from resilience_stats.models import ResilienceModel
 from resilience_stats.validators import validate_run_uuid
 from resilience_stats.views import run_outage_sim

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -40,7 +40,7 @@ from tastypie.serializers import Serializer
 from tastypie.validation import Validation
 
 from reo.exceptions import SaveToDatabase
-from reo.models import ScenarioModel
+from reo.models import ScenarioModel, FinancialModel, MessageModel
 from resilience_stats.models import ResilienceModel
 from resilience_stats.validators import validate_run_uuid
 from resilience_stats.views import run_outage_sim
@@ -131,6 +131,25 @@ def run_outage_sim_task(scenariomodel_id, run_uuid, bau):
 
     try:
         ResilienceModel.objects.filter(scenariomodel_id=scenariomodel_id).update(**results)
+        results = {'avoided_outage_costs_us_dollars': results['avoided_outage_costs_us_dollars']}
+        FinancialModel.objects.filter(run_uuid=run_uuid).update(**results)
+        deprecation_message = ("'Saving avoided outage costs within the Financial model, accessed from the /results endpoint,"
+                                " will be deprecated soon. Avoided outage costs then will only be accessible from the /resilience_stats endpoint.'")
+
+        m = MessageModel.objects.filter(run_uuid=run_uuid)
+        if len(m) == 0:
+            MessageModel.create(run_uuid=run_uuid, message=deprecation_message, message_type="warnings")
+        else:
+            m = m[0]
+            if  m.message in [None,'']:
+                m.message = 'Deprecations:['  + deprecation_message + ']'
+            else:
+                if "Deprecations': [" in m.message:
+                    m.message = m.message.replace("Deprecations': [", "Deprecations': [{} ".format(deprecation_message))
+                else:
+                    m.message += "'Deprecations': [{} ".format(deprecation_message)
+            m.save()
+        
     except SaveToDatabase as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         err = SaveToDatabase(exc_type, exc_value.args[0], exc_traceback, task='resilience_model', run_uuid=run_uuid)

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -138,7 +138,7 @@ def run_outage_sim_task(scenariomodel_id, run_uuid, bau):
 
         m = MessageModel.objects.filter(run_uuid=run_uuid)
         if len(m) == 0:
-            MessageModel.create(run_uuid=run_uuid, message=deprecation_message, message_type="warnings")
+            MessageModel.create(run_uuid=run_uuid, message="'Deprecations': [{} ".format(deprecation_message), message_type="warnings")
         else:
             m = m[0]
             if  m.message in [None,'']:

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -137,17 +137,18 @@ def run_outage_sim_task(scenariomodel_id, run_uuid, bau):
                                 " will be deprecated soon. Avoided outage costs then will only be accessible from the /resilience_stats endpoint.'")
 
         m = MessageModel.objects.filter(run_uuid=run_uuid)
+        full_message = 'Deprecations:['  + deprecation_message + ']'
         if len(m) == 0:
-            MessageModel.create(run_uuid=run_uuid, message="'Deprecations': [{} ".format(deprecation_message), message_type="warnings")
+            MessageModel.create(run_uuid=run_uuid, message=full_message, message_type="warnings")
         else:
             m = m[0]
             if  m.message in [None,'']:
-                m.message = 'Deprecations:['  + deprecation_message + ']'
+                m.message = full_message
             else:
                 if "Deprecations': [" in m.message:
                     m.message = m.message.replace("Deprecations': [", "Deprecations': [{} ".format(deprecation_message))
                 else:
-                    m.message += "'Deprecations': [{} ".format(deprecation_message)
+                    m.message += ", " + full_message
             m.save()
         
     except SaveToDatabase as e:

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -132,25 +132,7 @@ def run_outage_sim_task(scenariomodel_id, run_uuid, bau):
     try:
         ResilienceModel.objects.filter(scenariomodel_id=scenariomodel_id).update(**results)
         results = {'avoided_outage_costs_us_dollars': results['avoided_outage_costs_us_dollars']}
-        FinancialModel.objects.filter(run_uuid=run_uuid).update(**results)
-        deprecation_message = ("'Saving avoided outage costs within the Financial model, accessed from the /results endpoint,"
-                                " will be deprecated soon. Avoided outage costs then will only be accessible from the /resilience_stats endpoint.'")
-
-        m = MessageModel.objects.filter(run_uuid=run_uuid)
-        full_message = 'Deprecations:['  + deprecation_message + ']'
-        if len(m) == 0:
-            MessageModel.create(run_uuid=run_uuid, message=full_message, message_type="warnings")
-        else:
-            m = m[0]
-            if  m.message in [None,'']:
-                m.message = full_message
-            else:
-                if "Deprecations': [" in m.message:
-                    m.message = m.message.replace("Deprecations': [", "Deprecations': [{} ".format(deprecation_message))
-                else:
-                    m.message += ", " + full_message
-            m.save()
-        
+        FinancialModel.objects.filter(run_uuid=run_uuid).update(**results)        
     except SaveToDatabase as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         err = SaveToDatabase(exc_type, exc_value.args[0], exc_traceback, task='resilience_model', run_uuid=run_uuid)


### PR DESCRIPTION
## Changes
Saving avoided outage costs in the Financial Model to preserve backwards compatibility
Adding deprecation message for this functionality


Note: I moved the deprecation messages to the validator because before we were saving two versions of the warnings message in the db. This way we only save one version of the warnings message because we add the deprecations before initially saving to the database.