### PR TITLE
fix outage_start/_end_hour inputs

### DIFF
--- a/reo/models.py
+++ b/reo/models.py
@@ -833,5 +833,14 @@ class ModelManager(object):
 
         if resp['inputs']['Scenario']['Site']['LoadProfile'].get('doe_reference_name') == '':
             del resp['inputs']['Scenario']['Site']['LoadProfile']['doe_reference_name']
+        
+        #Preserving Backwards Compatability
+        resp['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] = resp['inputs']['Scenario']['Site']['LoadProfile'].get('outage_start_time_step')
+        if resp['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] is not None:
+            resp['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] -= 1
+        resp['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] = resp['inputs']['Scenario']['Site']['LoadProfile'].get('outage_end_time_step')
+        if resp['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] is not None:
+            resp['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] -= 1
+
 
         return resp

--- a/reo/process_results.py
+++ b/reo/process_results.py
@@ -985,13 +985,6 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
         if len(data['outputs']['Scenario']['Site']['PV']) == 1:
             data['outputs']['Scenario']['Site']['PV'] = data['outputs']['Scenario']['Site']['PV'][0]
 
-        #Preserving Backwards Compatability
-        data['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] = data['inputs']['Scenario']['Site']['LoadProfile'].get('outage_start_time_step')
-        if data['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] is not None:
-            data['inputs']['Scenario']['Site']['LoadProfile']['outage_start_hour'] -= 1
-        data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] = data['inputs']['Scenario']['Site']['LoadProfile'].get('outage_end_time_step')
-        if data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] is not None:
-            data['inputs']['Scenario']['Site']['LoadProfile']['outage_end_hour'] -= 1
         profiler.profileEnd()
         data['outputs']["Scenario"]["Profile"]["parse_run_outputs_seconds"] = profiler.getDuration()
 

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -39,7 +39,6 @@ from reo.src.urdb_rate import Rate
 import re
 import uuid
 from reo.src.techs import Generator
-from reo.nested_inputs import max_big_number
 from reo.src.emissions_calculator import EmissionsCalculator
 
 hard_problems_csv = os.path.join('reo', 'hard_problems.csv')
@@ -423,7 +422,7 @@ class ValidateNestedInput:
         self.defaults_inserted = []
         self.input_dict = dict()
         if type(input_dict) is not dict:
-            self.input_data_errors.append(("POST must contain a valid JSON formatted accoring to format described in "
+            self.input_data_errors.append(("POST must contain a valid JSON formatted according to format described in "
                                            "https://developer.nrel.gov/docs/energy-optimization/reopt-v1/"))
         else:        
             self.input_dict['Scenario'] = input_dict.get('Scenario') or {}
@@ -448,6 +447,10 @@ class ValidateNestedInput:
             if type(self.input_dict['Scenario']['Site']['PV']) == dict:
                 self.input_dict['Scenario']['Site']['PV']['pv_number'] = 1
                 self.input_dict['Scenario']['Site']['PV'] = [self.input_dict['Scenario']['Site']['PV']]
+
+            # the following inputs are deprecated and should not be saved to the database
+            del self.input_dict["Scenario"]["Site"]["LoadProfile"]["outage_start_hour"]
+            del self.input_dict["Scenario"]["Site"]["LoadProfile"]["outage_end_hour"]
 
     @property
     def isValid(self):

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -449,8 +449,8 @@ class ValidateNestedInput:
                 self.input_dict['Scenario']['Site']['PV'] = [self.input_dict['Scenario']['Site']['PV']]
 
             # the following inputs are deprecated and should not be saved to the database
-            del self.input_dict["Scenario"]["Site"]["LoadProfile"]["outage_start_hour"]
-            del self.input_dict["Scenario"]["Site"]["LoadProfile"]["outage_end_hour"]
+            self.input_dict["Scenario"]["Site"]["LoadProfile"].pop("outage_start_hour", None)
+            self.input_dict["Scenario"]["Site"]["LoadProfile"].pop("outage_end_hour", None)
 
     @property
     def isValid(self):


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [na] Tests for the changes have been added (for bug fixes / features)
- [na] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
reo/api.py saves the input_dict to the database with all values in reo/nested_inputs.py. However, `outage_start/end_hour` are no longer in the database but we have kept them in accepted inputs for backwards compatibility. So when api.py tries to save the inputs to the database it fails due to the missing fields for `outage_start/end_hour`.


* **What is the new behavior (if this is a feature change)?**
The `outage_start/end_hour` fields are now deleted from the input_dict in the validator before api.py saves to the database.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
