### PR TITLE
develop into master - 20210107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Classify the change according to the following categories:
 ##### Removed
 
 ### Patches
+- `resilience_stats`: Catch BAU cases and do not calculate avoided outage costs
+- `summary`: Catch jobs that errored out and do not parse results
 - `reo`: Catch `PVWattsDownloadError` when a bad response is received
 - `reo`: **fuel_used_gal** output for **Generator** was incorrect for scenarios with **time_steps_per_hour** not equal to 1
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,8 +85,8 @@ pipeline {
             stage("deploy-staging") {
               environment {
                 DEPLOY_ENV = "staging"
-                DEPLOY_SHARED_RESOURCES_NAMESPACE_POD_LIMIT = "4"
-                DEPLOY_APP_NAMESPACE_POD_LIMIT = "5"
+                DEPLOY_SHARED_RESOURCES_NAMESPACE_POD_LIMIT = "6"
+                DEPLOY_APP_NAMESPACE_POD_LIMIT = "6"
               }
 
               steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
                           --set='branchName=${BRANCH_NAME}' \
                           --set='ingressHost=${DEPLOY_BRANCH_DOMAIN}' \
                           --set='tempIngressHost=${tadaDeployBranchDomain(baseDomain: env.STAGING_TEMP_BASE_DOMAIN, primaryBranch: "master")}' \
-                          --set='dbName=${DEPLOY_BRANCH_DB_NAME}' \
+                          --set='dbName=${DEPLOY_BRANCH_DB_NAME}'
                       """
                     }
                   }
@@ -127,7 +127,7 @@ pipeline {
                           --values=./.helm/values.deploy.yaml \
                           --values=./.helm/values.${DEPLOY_ENV}.yaml \
                           --secret-values=./.helm/secret-values.${DEPLOY_ENV}.yaml \
-                          --set='ingressHost=${PRODUCTION_DOMAIN}' \
+                          --set='ingressHost=${PRODUCTION_DOMAIN}'
                       """
                     }
                   }

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1067,8 +1067,6 @@ class ValidateNestedInput:
                     # case of 'time_steps_per_hour' == 4 and outage_end_time_step > 35040 handled by "max" value
 
                 if real_values.get('outage_start_hour') is not None and real_values.get('outage_end_hour') is not None:
-                    self.warnings.append(("outage_start_hour and outage_end_hour will be deprecated soon in favor of "
-                                          "outage_start_time_step and outage_end_time_step"))
                     # the following preserves the original behavior
                     self.update_attribute_value(object_name_path, number, 'outage_start_time_step',
                                                 real_values.get('outage_start_hour') + 1)


### PR DESCRIPTION
## Patches
- `resilience_stats`: Catch BAU cases and do not calculate avoided outage costs
- `summary`: Catch jobs that resulted in an error and do not parse results, but send run_uuid's back for these jobs