### PR TITLE
Address rollbar issues

### DIFF
--- a/reo/models.py
+++ b/reo/models.py
@@ -1051,7 +1051,7 @@ class ModelManager(object):
         :return: None
         """
         d = data["outputs"]["Scenario"] 
-        ProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Profile']))        
+        ProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Profile']))
         SiteModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']))
         FinancialModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']['Financial']))
         LoadProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']['LoadProfile']))

--- a/reo/models.py
+++ b/reo/models.py
@@ -1051,7 +1051,7 @@ class ModelManager(object):
         :return: None
         """
         d = data["outputs"]["Scenario"] 
-        ProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Profile']))
+        ProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Profile']))        
         SiteModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']))
         FinancialModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']['Financial']))
         LoadProfileModel.objects.filter(run_uuid=run_uuid).update(**attribute_inputs(d['Site']['LoadProfile']))

--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -1421,6 +1421,7 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.0,
           "max": max_big_number,
+          "default": 0.0,          
           "description": "Minimum CHP size (based on electric) constraint for optimization"
         },
         "max_kw": {
@@ -1451,6 +1452,7 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.0,
           "max": 1.0e4,
+          "default": 0.0,           
           "description": "Annual CHP fixed operations and maintenance costs in $/kw-yr"
         },
         "om_cost_us_dollars_per_kwh": {
@@ -1463,6 +1465,7 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.0,
           "max": 1.0,
+          "default": 0.0,          
           "description": "CHP non-fuel variable operations and maintenance costs in $/hr/kw_rated"
         },
         "elec_effic_full_load": {
@@ -1504,18 +1507,21 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.1,
           "max": 1.5,
+          "default": 1.0,          
           "description": "Maximum derate factor; the y-axis value of the 'flat' part of the derate curve, on the left"
         },
         "derate_start_temp_degF": {
           "type": "float",
           "min": 0.0,
           "max": 150.0,
+          "default": 95.0,          
           "description": "The outdoor air temperature at which the power starts to derate, units of degrees F"
         },
         "derate_slope_pct_per_degF": {
           "type": "float",
           "min": 0.0,
           "max": 1.0,
+          "default": 0.0,            
           "description": "Derate slope as a percent/fraction of rated power per degree F"
         },
         "chp_unavailability_periods": {

--- a/reo/process_results.py
+++ b/reo/process_results.py
@@ -788,7 +788,6 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
                     "developer_om_and_replacement_present_cost_after_tax_us_dollars"] = \
                     self.nested_outputs["Scenario"]["Site"]["Financial"][
                         "om_and_replacement_present_cost_after_tax_us_dollars"] / self.third_party_factor
-
             if self.nested_outputs["Scenario"]["Site"]["LoadProfile"]["annual_calculated_kwh"] > 0:
                 self.nested_outputs["Scenario"]["Site"]["renewable_electricity_energy_pct"] = \
                     self.nested_outputs["Scenario"]["Site"]["Wind"].get("average_yearly_energy_produced_kwh") or 0
@@ -798,6 +797,9 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
                 self.nested_outputs["Scenario"]["Site"]["renewable_electricity_energy_pct"] = round(
                     self.nested_outputs["Scenario"]["Site"]["renewable_electricity_energy_pct"] /
                     self.nested_outputs["Scenario"]["Site"]["LoadProfile"]["annual_calculated_kwh"], 4)
+            else:
+                #If this is not set to None it will contain a dictionary of data parameters
+                self.nested_outputs["Scenario"]["Site"]["renewable_electricity_energy_pct"] = None
 
             time_outputs = [k for k in self.bau_attributes if (k.startswith("julia") or k.startswith("pyjulia"))]
 

--- a/reo/scenario.py
+++ b/reo/scenario.py
@@ -44,7 +44,7 @@ from reo.src.storage import Storage, HotTES, ColdTES
 from reo.src.techs import PV, Util, Wind, Generator, CHP, Boiler, ElectricChiller, AbsorptionChiller
 from celery import shared_task, Task
 from reo.models import ModelManager
-from reo.exceptions import REoptError, UnexpectedError, LoadProfileError, WindDownloadError, PVWattsDownloadError
+from reo.exceptions import REoptError, UnexpectedError, LoadProfileError, WindDownloadError, PVWattsDownloadError, RequestError
 
 
 class ScenarioTask(Task):
@@ -382,6 +382,9 @@ def setup_scenario(self, run_uuid, data, raw_post):
                             message += (" from the NSRDB or international datasets. No search threshold was specified when "
                                         "attempting to pull solar resource data from either dataset.")
                         raise PVWattsDownloadError(message=message, task=self.name, run_uuid=run_uuid, user_uuid=self.data['inputs']['Scenario'].get('user_uuid'), traceback=e.args[0])
+                    if e.args[0].startswith("Invalid cost curve"):
+                        raise RequestError(message=e.args[0], task='data_manager.py', run_uuid=run_uuid, user_uuid=self.data['inputs']['Scenario'].get('user_uuid')) 
+
 
         exc_type, exc_value, exc_traceback = sys.exc_info()
         log.error("Scenario.py raising error: " + str(exc_value.args[0]))

--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -529,7 +529,7 @@ class DataManager:
 
                 # Following logic modifies the cap cost segments to account for the tax benefits of the ITC and MACRs
                 updated_cap_cost_slope = list()
-                updated_y_intercept = list()
+                updated_y_intercept = list()                
 
                 for s in range(n_segments):
 
@@ -540,8 +540,14 @@ class DataManager:
                         if itc is None or rebate_federal is None:
                             itc = 0.0
                             rebate_federal = 0.0
-                        itc_unit_basis = (tmp_cap_cost_slope[s] + rebate_federal) / (1 - itc)
-
+                        if itc == 1:
+                            itc_unit_basis = 0
+                        else:
+                            itc_unit_basis = (tmp_cap_cost_slope[s] + rebate_federal) / (1 - itc)
+                    else:
+                        # Not sure how else to handle this case, perhaps there is a better way to handle it?
+                        raise Exception('Invalid cost curve for {}. Value at index {} ({}) cannot be less than or equal to 0'.format(tech, s, cost_curve_bp_x[s + 1]))
+                        
                     sf = self.site.financial
                     updated_slope = setup_capital_cost_incentive(
                         itc_basis=itc_unit_basis,  # input tech cost with incentives, but no ITC

--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -529,7 +529,7 @@ class DataManager:
 
                 # Following logic modifies the cap cost segments to account for the tax benefits of the ITC and MACRs
                 updated_cap_cost_slope = list()
-                updated_y_intercept = list()                
+                updated_y_intercept = list()
 
                 for s in range(n_segments):
 
@@ -547,7 +547,7 @@ class DataManager:
                     else:
                         # Not sure how else to handle this case, perhaps there is a better way to handle it?
                         raise Exception('Invalid cost curve for {}. Value at index {} ({}) cannot be less than or equal to 0'.format(tech, s, cost_curve_bp_x[s + 1]))
-                        
+
                     sf = self.site.financial
                     updated_slope = setup_capital_cost_incentive(
                         itc_basis=itc_unit_basis,  # input tech cost with incentives, but no ITC

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1163,7 +1163,7 @@ class ValidateNestedInput:
                         required_keys = prime_mover_defaults_all['recip_engine'].keys()
                         if real_values.get('prime_mover') is None:
                             self.input_data_errors.append('No prime_mover was input so all cost and performance parameters must be input.')
-                        filtered_values = {k: real_values.get(k) for k in required_keys if k is not 'prime_mover'}
+                        filtered_values = {k: real_values.get(k) for k in required_keys if k not in ['prime_mover', 'size_class']}
                         missing_defaults = []
                         for k,v in filtered_values.items():
                             if v is None:

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1161,15 +1161,13 @@ class ValidateNestedInput:
                     # check if user intended to run CHP and supplied sufficient pararmeters to run CHP
                     if user_supplied_chp_inputs:
                         required_keys = prime_mover_defaults_all['recip_engine'].keys()
-                        if real_values.get('prime_mover') is None:
-                            self.input_data_errors.append('No prime_mover was input so all cost and performance parameters must be input.')
                         filtered_values = {k: real_values.get(k) for k in required_keys if k not in ['prime_mover', 'size_class']}
                         missing_defaults = []
                         for k,v in filtered_values.items():
                             if v is None:
                                 missing_defaults.append(k)
                         if len(missing_defaults) > 0:                               
-                            self.input_data_errors.append("CHP is missing a value for the following inputs which are dependent on prime mover type: " + ', '.join(missing_defaults))
+                            self.input_data_errors.append("'No prime_mover was input so all cost and performance parameters must be input for CHP. Please send a new job with the following missing CHP attributes filled in: " + ', '.join(missing_defaults))
                         if real_values.get("chp_unavailability_periods") is None:
                             self.input_data_errors.append('Must provide an input for chp_unavailability_periods since not providing prime_mover')
                         else:

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1456,8 +1456,13 @@ class ValidateNestedInput:
                         self.input_data_errors.append(
                         'The sum of elements of percent share list for hybrid LoadProfileChillerThermal should be 100.')
                 if real_values.get('percent_share') is None:
-                    real_values['percent_share'] = self.input_dict['Scenario']['Site']['LoadProfile'].get(
+                    if len(real_values['doe_reference_name']) == 1:
+                        real_values['percent_share'] = [100]
+                    elif real_values['doe_reference_name'] == self.input_dict['Scenario']['Site']['LoadProfile']['doe_reference_name']:
+                        real_values['percent_share'] = self.input_dict['Scenario']['Site']['LoadProfile'].get(
                                                 'percent_share')
+                    else:
+                        real_values['percent_share'] = []
                     self.update_attribute_value(object_name_path, number, 'percent_share', real_values['percent_share'])
                 if real_values.get('doe_reference_name') is not None:
                     if len(real_values.get('doe_reference_name')) != len(real_values.get('percent_share',[])):

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1455,7 +1455,7 @@ class ValidateNestedInput:
                     if percent_share_sum != 100.0:
                         self.input_data_errors.append(
                         'The sum of elements of percent share list for hybrid LoadProfileChillerThermal should be 100.')
-                if real_values.get('percent_share') is None:
+                if real_values.get('percent_share') is None and real_values.get('doe_reference_name') is not None:
                     if len(real_values['doe_reference_name']) == 1:
                         real_values['percent_share'] = [100]
                     elif real_values['doe_reference_name'] == self.input_dict['Scenario']['Site']['LoadProfile']['doe_reference_name']:
@@ -1514,7 +1514,7 @@ class ValidateNestedInput:
                     if percent_share_sum != 100.0:
                         self.input_data_errors.append(
                         'The sum of elements of percent share list for hybrid boiler load profile should be 100.')
-                if real_values.get('percent_share') is None:
+                if real_values.get('percent_share') is None and real_values.get('doe_reference_name') is not None:
                     if len(real_values['doe_reference_name']) == 1:
                         real_values['percent_share'] = [100]
                     elif real_values['doe_reference_name'] == self.input_dict['Scenario']['Site']['LoadProfile']['doe_reference_name']:

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1169,7 +1169,7 @@ class ValidateNestedInput:
                             if v is None:
                                 missing_defaults.append(k)
                         if len(missing_defaults) > 0:                               
-                            self.input_data_errors.append("CHP is missing a value for the following defaults: " + ', '.join(missing_defaults))
+                            self.input_data_errors.append("CHP is missing a value for the following inputs which are dependent on prime mover type: " + ', '.join(missing_defaults))
                         if real_values.get("chp_unavailability_periods") is None:
                             self.input_data_errors.append('Must provide an input for chp_unavailability_periods since not providing prime_mover')
                         else:
@@ -1510,8 +1510,13 @@ class ValidateNestedInput:
                         self.input_data_errors.append(
                         'The sum of elements of percent share list for hybrid boiler load profile should be 100.')
                 if real_values.get('percent_share') is None:
-                    real_values['percent_share'] = self.input_dict['Scenario']['Site']['LoadProfile'].get(
+                    if len(real_values['doe_reference_name']) == 1:
+                        real_values['percent_share'] = [100]
+                    elif real_values['doe_reference_name'] == self.input_dict['Scenario']['Site']['LoadProfile']['doe_reference_name']:
+                        real_values['percent_share'] = self.input_dict['Scenario']['Site']['LoadProfile'].get(
                                                 'percent_share')
+                    else:
+                        real_values['percent_share'] = []
                     self.update_attribute_value(object_name_path, number, 'percent_share', real_values['percent_share'])
                 if real_values.get('doe_reference_name') is not None:
                     if len(real_values.get('doe_reference_name')) != len(real_values.get('percent_share',[])):


### PR DESCRIPTION
## Patches
- `reo`: Catch issue in `process_results.py` where `renewable_electricity_energy_pct` is not explicitly set to _None_
- `reo`:  Catch case where `CHP` `prime_mover` is not set and not all required fields are filled in
- `reo`:  Catch issues with `itc_unit_basis` when the ITC is 100%
- `validators.py`: Fix bug where length of percent_share != length of doe_reference_name even though no percent_share is provided (in `LoadProfileBoilerFuel`)
