### PR TITLE
address international pvwatts bug

### DIFF
--- a/reo/src/pvwatts.py
+++ b/reo/src/pvwatts.py
@@ -131,18 +131,22 @@ class PVWatts:
         self.response = None
         self.response = self.data  # store response so don't hit API multiple times
         if self.tilt is None:
-            if self.latitude < 0: # if the site is in the southern hemisphere, and no tilt has been specified, then set the tilt to the positive latitude value and change the azimuth to zero
+            # if the site is in the southern hemisphere, and no tilt has been specified,
+            # then set the tilt to the positive latitude value and change the azimuth to zero
+            if self.latitude < 0:
                 self.tilt = self.latitude * -1
                 self.azimuth = 0
             else:
-                self.tilt = self.latitude # if the site is in the norther hemisphere, and no tilt has been specified, then set the tilt to the latitude value and leave the azimuth at 180
+                # if the site is in the norther hemisphere, and no tilt has been specified,
+                # then set the tilt to the latitude value
+                self.tilt = self.latitude
 
     @property
     def url(self):
         url = self.url_base + "?api_key=" + self.key + "&azimuth=" + str(self.azimuth) + \
               "&system_capacity=" + str(self.system_capacity) + "&losses=" + str(self.losses*100) + \
               "&array_type=" + str(self.array_type) + "&module_type=" + str(self.module_type) + \
-              "&timeframe=" + self.timeframe +"&gcr=" + str(self.gcr) +  "&dc_ac_ratio=" + str(self.dc_ac_ratio) + \
+              "&timeframe=" + self.timeframe + "&gcr=" + str(self.gcr) +  "&dc_ac_ratio=" + str(self.dc_ac_ratio) + \
               "&inv_eff=" + str(self.inv_eff*100) + "&radius=" + str(int(self.radius)) + "&dataset=" + self.dataset + \
               "&lat=" + str(self.latitude) + "&lon=" + str(self.longitude) + "&tilt=" + str(self.tilt)
         return url
@@ -150,7 +154,7 @@ class PVWatts:
     @property
     def data(self):
         if self.response is None:
-            # Check if point is beyond thr bounds of the NRSDB dataset, if use the international dataset
+            # Check if point is beyond the bounds of the NRSDB dataset, if so use the international dataset
             if self.latitude < -59.5 or self.latitude > 60.01 or self.longitude > -22.37 or self.longitude < -179.58 :
                 self.dataset = 'intl'
                 self.radius = self.radius *2
@@ -192,15 +196,13 @@ class PVWatts:
 
         else:
             prod_factor_original = list()
-            prod_factor = list()
             import os
             with open(os.path.join('reo', 'tests', 'offline_pv_prod_factor.txt'), 'r') as f:
                 for line in f:
                     prod_factor_original.append(float(line.strip('\n')))
 
-            # the stored values in offline_pv_prod_factor.txt are 8760 rows, thus modifying prod_factor list
-            # to have 8760*4 values
-
+            # offline_pv_prod_factor.txt has 8760 rows, thus modifying prod_factor list
+            # to have 8760 * time_steps_per_hour values
             prod_factor = [val for val in prod_factor_original for _ in range(self.time_steps_per_hour)]
 
         return prod_factor

--- a/reo/src/pvwatts.py
+++ b/reo/src/pvwatts.py
@@ -151,7 +151,7 @@ class PVWatts:
     def data(self):
         if self.response is None:
             # Check if point is beyond thr bounds of the NRSDB dataset, if use the international dataset
-            if self.latitude < -18.4 or self.latitude > 59.9 or self.longitude > -47.2 or self.longitude < -178.2 :
+            if self.latitude < -59.5 or self.latitude > 60.01 or self.longitude > -22.37 or self.longitude < -179.58 :
                 self.dataset = 'intl'
                 self.radius = self.radius *2
             resp = requests.get(self.url, verify=self.verify)


### PR DESCRIPTION
## Bug Fix

The PVWatts warning about being outside the US may have changed, so there is no trigger to tell the API to use the international dataset. We now use the international dataset if the site is outside the bounds of the NSRDB https://nsrdb.nrel.gov/