### PR TITLE
Ghp hybridloads

### DIFF
--- a/reo/src/load_profile.py
+++ b/reo/src/load_profile.py
@@ -474,7 +474,6 @@ class BuiltInProfile(object):
         self.year = 2017
         self.annual_energy = annual_energy if annual_energy is not None else (
             sum(monthly_totals_energy) if monthly_totals_energy else self.default_annual_energy)
-        self.annual_kwh = round(self.annual_energy,0)
         self.user_entered_space_heating_fraction = kwargs.get("space_heating_fraction")
         
 

--- a/reo/src/load_profile_chiller_thermal.py
+++ b/reo/src/load_profile_chiller_thermal.py
@@ -100,14 +100,14 @@ class LoadProfileChillerThermal(BuiltInProfile):
             # In the case where the user supplies a list of doe_reference_names and percent shares
             # WITHOUT an annual_energy (tonhour) value, then we use the weighted average (by percent_share)
             #  of the fraction of total electric load
-            if (len(doe_reference_name) > 1) and kwargs.get('annual_energy') is None:
+            if kwargs.get('annual_energy') is None:
                 for i, building in enumerate(doe_reference_name):
                     default_fraction = np.array(self.get_default_fraction_of_total_electric(building))
                     modified_fraction = default_fraction * kwargs.get("percent_share")[i]/100.0
                     combine_loadlist[i] = list(np.array(total_electric_load_list) * modified_fraction)
             
             #Apply the percent share of annual load to each partial load
-            if (len(doe_reference_name) > 1):
+            elif (len(doe_reference_name) > 1):
                 for i, load in enumerate(combine_loadlist):
                     combine_loadlist[i] = list(np.array(load) * (kwargs.get("percent_share")[i]/100.0))
 

--- a/reo/src/load_profile_chiller_thermal.py
+++ b/reo/src/load_profile_chiller_thermal.py
@@ -1,4 +1,4 @@
-from reo.src.load_profile import library_path_base, BuiltInProfile
+from reo.src.load_profile import library_path_base, BuiltInProfile, default_annual_electric_loads
 import os
 import json
 import pandas as pd
@@ -98,16 +98,13 @@ class LoadProfileChillerThermal(BuiltInProfile):
                 combine_loadlist.append(list(partial_load_list))
 
             # In the case where the user supplies a list of doe_reference_names and percent shares
-            # for consistency we want to act as if we had scaled the partial load to the total site 
-            # load which was unknown at the start of the loop above. This scalar makes it such that
-            # when the percent shares are later applied that the total site load will be the sum
-            # of the default annual loads for this location
-            if (len(doe_reference_name) > 1) and kwargs['annual_energy'] is None:
-                total_site_load = sum([sum(l) for l in combine_loadlist])
-                for i, load in enumerate(combine_loadlist):
-                    actual_percent_of_site_load = sum(load)/total_site_load
-                    scalar = 1.0 / actual_percent_of_site_load
-                    combine_loadlist[i] = list(np.array(load)* scalar)
+            # WITHOUT an annual_energy (tonhour) value, then we use the weighted average (by percent_share)
+            #  of the fraction of total electric load
+            if (len(doe_reference_name) > 1) and kwargs.get('annual_energy') is None:
+                for i, building in enumerate(doe_reference_name):
+                    default_fraction = np.array(self.get_default_fraction_of_total_electric(building))
+                    modified_fraction = default_fraction * kwargs.get("percent_share")[i]/100.0
+                    combine_loadlist[i] = list(np.array(total_electric_load_list) * modified_fraction)
             
             #Apply the percent share of annual load to each partial load
             if (len(doe_reference_name) > 1):
@@ -154,5 +151,21 @@ class LoadProfileChillerThermal(BuiltInProfile):
         if electric_load_list is not None:            
             self.load_list = [i*self.chiller_cop for i in electric_load_list]
         self.annual_kwht = int(round(sum(self.load_list),0))
+    
         if dfm is not None:
             dfm.add_load_chiller_thermal(self)
+       
+    def get_default_fraction_of_total_electric(self, doe_reference_name):
+        elec_bip = BuiltInProfile(annual_loads=default_annual_electric_loads, load_type='Electric',
+                 latitude=self.latitude, longitude=self.longitude, doe_reference_name=doe_reference_name)
+        default_total_elec_load_profile = elec_bip.built_in_profile
+
+        cool_bip = BuiltInProfile(annual_loads=LoadProfileChillerThermal.annual_loads, load_type='Cooling',
+                 latitude=self.latitude, longitude=self.longitude, doe_reference_name=doe_reference_name)
+        default_cooling_elec_load_profile = cool_bip.built_in_profile
+        
+        default_fraction_of_total_electric_profile = [default_cooling_elec_load_profile[i] / \
+                                                        default_total_elec_load_profile[i] 
+                                                        for i in range(len(default_total_elec_load_profile))]
+
+        return default_fraction_of_total_electric_profile

--- a/reo/tests/test_heating_and_cooling_profiles.py
+++ b/reo/tests/test_heating_and_cooling_profiles.py
@@ -102,8 +102,10 @@ class HeatingCoolingTest(ResourceTestCaseMixin, TestCase):
         d = ModelManager.make_response(run_uuid=run_uuid)
         self.assertEqual(round(d['outputs']['Scenario']['Site']['LoadProfileBoilerFuel']['annual_calculated_boiler_fuel_load_mmbtu_bau'],-1), 2900)
         self.assertEqual(round(sum(d['outputs']['Scenario']['Site']['LoadProfileBoilerFuel']['year_one_boiler_fuel_load_series_mmbtu_per_hr']),-1), 2900)
-        self.assertEqual(round(d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['annual_calculated_kwh_bau'],-1),297490)
-        self.assertEqual(round(sum(d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['year_one_chiller_electric_load_series_kw_bau']),-1), 297490)
+        # The expected cooling load is based on the default **fraction of total electric** profile for the doe_reference_name when annual_tonhour is NOT input
+        #    the 320540.0 kWh number is from the default LargeOffice fraction of total electric profile applied to the Hospital default total electric profile
+        self.assertEqual(round(d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['annual_calculated_kwh_bau'],-1), 320540.0)
+        self.assertEqual(round(sum(d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['year_one_chiller_electric_load_series_kw_bau']),-1), 320540.0)
 
         post['Scenario']['Site']['LoadProfileBoilerFuel']['doe_reference_name'] = None
         post['Scenario']['Site']['LoadProfileChillerThermal']['doe_reference_name'] = None        

--- a/reo/tests/test_hybridloads_heat_cool.py
+++ b/reo/tests/test_hybridloads_heat_cool.py
@@ -1,0 +1,155 @@
+import json
+import copy
+import os
+import pandas as pd
+from tastypie.test import ResourceTestCaseMixin
+from reo.nested_to_flat_output import nested_to_flat
+from unittest import TestCase  # have to use unittest.TestCase to get tests to store to database, django.test.TestCase flushes db
+from unittest import skip
+from reo.models import ModelManager
+from reo.utilities import check_common_outputs
+from reo.validators import ValidateNestedInput
+import pandas as pd
+import numpy as np
+from unittest import skip
+from reo.utilities import TONHOUR_TO_KWHT
+
+post = {
+        "Scenario": {
+            "Site": {
+            "latitude": 37.78,
+            "longitude": -122.45,
+            "LoadProfile": {
+                # "annual_kwh": 100,
+                # "doe_reference_name": "Hospital",
+                #"doe_reference_name": ["Hospital", "LargeHotel"],
+                #"percent_share": [50, 50]
+            },
+            "LoadProfileBoilerFuel": {
+                # "doe_reference_name": ["Hospital", "LargeHotel"],
+                # "percent_share": [50, 50]
+            },
+            "LoadProfileChillerThermal": {
+                # "doe_reference_name": ["Hospital", "LargeHotel"],
+                # "percent_share": [50, 50],
+                # "chiller_cop": 3.4
+            },
+            "ElectricTariff": {
+                "urdb_label": "5cef0a415457a33576f60fe2"
+            },
+            # "FuelTariff": {
+            #     "boiler_fuel_blended_annual_rates_us_dollars_per_mmbtu": 11.0,
+            #     "chp_fuel_blended_annual_rates_us_dollars_per_mmbtu": 11.0
+            # },
+            # "Boiler": {
+            #     "existing_boiler_production_type_steam_or_hw": "hot_water"
+            # },
+            "PV": {
+                "min_kw": 0.0,
+                "max_kw": 0.0
+            },
+            "Storage": {
+                "min_kw": 0.0,
+                "max_kw": 0.0,
+                "min_kwh": 0.0,
+                "max_kwh": 0.0
+            }
+        }}}
+
+class HybridLoadsHeatCoolTest(ResourceTestCaseMixin, TestCase):
+    REopt_tol = 1e-2
+
+    def setUp(self):
+        super(HybridLoadsHeatCoolTest, self).setUp()
+        self.reopt_base = '/v1/job/'
+
+    def get_response(self, data):
+        return self.api_client.post(self.reopt_base, format='json', data=data)
+
+    def test_heat_cool_energy_balance(self):
+        """
+
+        Check that hybrid loads for electric is working as expected, and heating and cooling work too
+
+        """
+
+        hospital_pct = 75.0
+        hotel_pct = 100 - hospital_pct
+
+        # Hospital only
+        post["Scenario"]["Site"]["LoadProfile"]["annual_kwh"] = hospital_pct
+        post["Scenario"]["Site"]["LoadProfile"]["doe_reference_name"] = "Hospital"
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["annual_mmbtu"] = hospital_pct
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["doe_reference_name"] = "Hospital"
+        post["Scenario"]["Site"]["LoadProfileChillerThermal"]["doe_reference_name"] = "Hospital"
+
+        resp = self.get_response(data=post)
+        self.assertHttpCreated(resp)
+        r = json.loads(resp.content)
+        run_uuid = r.get('run_uuid')
+        d = ModelManager.make_response(run_uuid=run_uuid)
+
+        lp_hospital = d['outputs']['Scenario']['Site']['LoadProfile']["year_one_electric_load_series_kw"]
+        lpbf_hospital = d['outputs']['Scenario']['Site']['LoadProfileBoilerFuel']["year_one_boiler_fuel_load_series_mmbtu_per_hr"]
+        lpct_hospital = d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['year_one_chiller_electric_load_series_kw']
+        lpct_hospital_frac_of_total = [lpct_hospital[i] / lp_hospital[i] for i in range(len(lp_hospital))]
+
+        # Hotel only
+        post["Scenario"]["Site"]["LoadProfile"]["annual_kwh"] = hotel_pct
+        post["Scenario"]["Site"]["LoadProfile"]["doe_reference_name"] = "LargeHotel"
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["annual_mmbtu"] = hotel_pct
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["doe_reference_name"] = "LargeHotel"
+        post["Scenario"]["Site"]["LoadProfileChillerThermal"]["doe_reference_name"] = "LargeHotel"
+
+        resp = self.get_response(data=post)
+        self.assertHttpCreated(resp)
+        r = json.loads(resp.content)
+        run_uuid = r.get('run_uuid')
+        d = ModelManager.make_response(run_uuid=run_uuid)
+
+        lp_largehotel = d['outputs']['Scenario']['Site']['LoadProfile']["year_one_electric_load_series_kw"]
+        lpbf_largehotel = d['outputs']['Scenario']['Site']['LoadProfileBoilerFuel']["year_one_boiler_fuel_load_series_mmbtu_per_hr"]
+        lpct_largehotel = d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['year_one_chiller_electric_load_series_kw']
+        lpct_largehotel_frac_of_total = [lpct_largehotel[i] / lp_largehotel[i] for i in range(len(lp_largehotel))]
+
+        # Hybrid mix of hospital and hotel
+        annual_energy = hospital_pct + hotel_pct
+        building_list = ["Hospital", "LargeHotel"]
+        percent_share_list = [hospital_pct, hotel_pct]
+        post["Scenario"]["Site"]["LoadProfile"]["annual_kwh"] = annual_energy
+        post["Scenario"]["Site"]["LoadProfile"]["doe_reference_name"] = building_list
+        post["Scenario"]["Site"]["LoadProfile"]["percent_share"] = percent_share_list
+        
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["annual_mmbtu"] = annual_energy
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["doe_reference_name"] = building_list
+        post["Scenario"]["Site"]["LoadProfileBoilerFuel"]["percent_share"] = percent_share_list
+
+        # API should now use a weighted fraction of total electric profile if no annual_tonhour is provided
+        post["Scenario"]["Site"]["LoadProfileChillerThermal"]["doe_reference_name"] = building_list
+        post["Scenario"]["Site"]["LoadProfileChillerThermal"]["percent_share"] = percent_share_list
+
+        resp = self.get_response(data=post)
+        self.assertHttpCreated(resp)
+        r = json.loads(resp.content)
+        run_uuid = r.get('run_uuid')
+        d = ModelManager.make_response(run_uuid=run_uuid)
+
+        lp_combined = d['outputs']['Scenario']['Site']['LoadProfile']["year_one_electric_load_series_kw"]
+        lpbf_combined = d['outputs']['Scenario']['Site']['LoadProfileBoilerFuel']["year_one_boiler_fuel_load_series_mmbtu_per_hr"]
+        lpct_combined = d['outputs']['Scenario']['Site']['LoadProfileChillerThermal']['year_one_chiller_electric_load_series_kw']
+
+        # Check that the combined/hybrid load is the same as the sum of the individual loads in each timestep
+        self.assertAlmostEqual(0.0, sum([lp_combined[i] - (lp_hospital[i] + lp_largehotel[i]) for i in range(len(lp_combined))]), places=3)
+        self.assertAlmostEqual(0.0, sum([lpbf_combined[i] - (lpbf_hospital[i] + lpbf_largehotel[i]) for i in range(len(lpbf_combined))]), places=3)
+        
+        # Check that the cooling load is the weighted average of the default CRB fraction of total electric profiles
+        lpct_combined_expected = [lp_combined[i] * (lpct_hospital_frac_of_total[i] * hospital_pct / 100.0 + 
+                                                    lpct_largehotel_frac_of_total[i] * hotel_pct / 100.0)
+                                                    for i in range(len(lp_combined))]
+        self.assertAlmostEqual(0.0, sum([lpct_combined_expected[i] - lpct_combined[i] for i in range(len(lpct_combined))]), places=3)
+
+        
+
+
+
+


### PR DESCRIPTION
Change cooling load behavior for when CRB's are used with NO annual_tonhour, which is a common use case because cooling electric load is not normally metered:
- To avoid the issue of the cooling electric load being greater than the total electric load (non-sense) based on user-input/CRB inconsistency, we use the weighted average fraction of total electric for the cooling load buildings and apply that to the total electric load.
