### PR TITLE
Change optimality_tolerance min and max values

### DIFF
--- a/.helm/values.production.yaml
+++ b/.helm/values.production.yaml
@@ -1,5 +1,5 @@
 appEnv: production
 djangoSettingsModule: reopt_api.production_settings
-djangoReplicas: 3
-celeryReplicas: 18
-juliaReplicas: 18
+djangoReplicas: 4
+celeryReplicas: 20
+juliaReplicas: 20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Below are guidelines for making contributions to REopt Lite.
 
 
 ### I don't want to read this whole thing I just have a question!!!
-Please do not create an "issue" if you have a question. We will have a discussion board soon. You might find answers to general questions on our [REopt-API-Analysis Discussion Board](https://github.com/NREL/REopt-API-Analysis/discussions/) or [our web site](https://reopt.nrel.gov/) and you can reach us at [reopt@nrel.gov](mailto:reopt@nrel.gov). 
+Please do not create an "issue" if you have a question. You might find answers to general questions on our [REopt-API-Analysis Discussion Board](https://github.com/NREL/REopt-API-Analysis/discussions/) or [our web site](https://reopt.nrel.gov/) and you can reach us at [reopt@nrel.gov](mailto:reopt@nrel.gov). 
 
 ## How Can I Contribute?
 

--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -132,15 +132,15 @@ nested_input_definitions = {
     },
   "optimality_tolerance_bau": {
       "type": "float",
-      "min": 1.0e-5,
-      "max": 10.0,
+      "min": 0.0005,
+      "max": 0.05,
       "default": 0.001,
       "description": "The threshold for the difference between the solution's objective value and the best possible value at which the solver terminates"
     },
   "optimality_tolerance_techs": {
       "type": "float",
-      "min": 1.0e-5,
-      "max": 10.0,
+      "min": 0.0005,
+      "max": 0.05,
       "default": 0.001,
       "description": "The threshold for the difference between the solution's objective value and the best possible value at which the solver terminates"
     },

--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -132,14 +132,14 @@ nested_input_definitions = {
     },
   "optimality_tolerance_bau": {
       "type": "float",
-      "min": 0.0005,
+      "min": 0.0001,
       "max": 0.05,
       "default": 0.001,
       "description": "The threshold for the difference between the solution's objective value and the best possible value at which the solver terminates"
     },
   "optimality_tolerance_techs": {
       "type": "float",
-      "min": 0.0005,
+      "min": 0.0001,
       "max": 0.05,
       "default": 0.001,
       "description": "The threshold for the difference between the solution's objective value and the best possible value at which the solver terminates"

--- a/reo/tests/posts/noTechs_POST.json
+++ b/reo/tests/posts/noTechs_POST.json
@@ -1,7 +1,7 @@
 {
   "Scenario": {
     "timeout_seconds": 420,
-    "optimality_tolerance_techs": 0.07,
+    "optimality_tolerance_techs": 0.05,
 	"add_soc_incentive": false,
     "Site": {
       "latitude": 37.78,

--- a/reo/tests/test_heating_and_cooling_profiles.py
+++ b/reo/tests/test_heating_and_cooling_profiles.py
@@ -14,7 +14,7 @@ from reo.src.wind import WindSAMSDK, combine_wind_files
 
 post = {"Scenario": {
     "timeout_seconds": 420,
-    "optimality_tolerance_techs": 0.7,
+    "optimality_tolerance_techs": 0.05,
     "Site": {
     "latitude": 37.78, "longitude": -122.45,
     "Financial": {
@@ -30,14 +30,12 @@ post = {"Scenario": {
     "LoadProfileBoilerFuel": {
         "doe_reference_name": "LargeOffice",
     },
+    "LoadProfileChillerThermal": {
+        "doe_reference_name": "LargeOffice",
+    },    
     "ElectricTariff": {
-        "urdb_label": '5cef0a415457a33576f60fe2',
-        #"eia": '14328', # May not be setup to take this input
-        #"urdb_rate_name": "E-19 Medium General Demand TOU",
-        #"blended_monthly_rates_us_dollars_per_kwh": [0.09] * 12,
-        #"blended_monthly_demand_charges_us_dollars_per_kw": [22] * 12,
-        "net_metering_limit_kw": 1e6,
-        "wholesale_rate_us_dollars_per_kwh": 0
+        "blended_annual_rates_us_dollars_per_kwh": 0.06,
+        "blended_annual_demand_charges_us_dollars_per_kw": 0.0
     },
     "FuelTariff": {
         "existing_boiler_fuel_type": "natural_gas",
@@ -45,39 +43,18 @@ post = {"Scenario": {
         "chp_fuel_type": "natural_gas",
         "chp_fuel_blended_monthly_rates_us_dollars_per_mmbtu": [11.0]*12
     },
+    "PV": {
+        "max_kw": 0,
+    },    
     "Storage": {
         "max_kwh": 0,
-        "max_kw": 0,
-        "installed_cost_us_dollars_per_kw": 1000,
-        "installed_cost_us_dollars_per_kwh": 500,
-        "replace_cost_us_dollars_per_kw": 460,
-        "replace_cost_us_dollars_per_kwh": 230,
-        "macrs_option_years": 0,
-    },
-    "LoadProfileChillerThermal": {
-        "doe_reference_name": "LargeOffice",
+        "max_kw": 0
     },
     "ElectricChiller": {
     },
     "Boiler": {
         "boiler_efficiency": 0.8,
         "existing_boiler_production_type_steam_or_hw": "steam",
-    },
-    "ColdTES": {
-        "min_gal": 0,
-        "max_gal": 0,
-        "installed_cost_us_dollars_per_gal": 3,
-        "thermal_decay_rate_fraction": 0.004,
-        "om_cost_us_dollars_per_gal": 0,
-        "internal_efficiency_pct": 0.97,
-    },
-    "HotTES": {
-        "min_gal": 0,
-        "max_gal": 0,
-        "installed_cost_us_dollars_per_gal": 3,
-        "thermal_decay_rate_fraction": 0.004,
-        "om_cost_us_dollars_per_gal": 0,
-        "internal_efficiency_pct": 0.97,
     }
 }}}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ Shapely==1.7.1
 six==1.15.0
 smmap==3.0.5
 SQLAlchemy==1.3.23
-sqlparse==0.4.1
+sqlparse==0.4.2
 stevedore==3.3.0
 toml==0.10.2
 traitlets==4.3.3


### PR DESCRIPTION
Change `optimality_tolerance_[bau and techs]` (MIPRELSTOP) min and max values in `nested_inputs.py`:
1. `min`: change from 1e-5 to 1e-4 (0.0001), which is also the default MIPRELSTOP in Xpress
2. `max`: change from 10 (non-sensical, 1000%) to 0.05 (5%)

I had to simplify the POST for `test_heating_and_cooling_profiles` which had an `optimality_tolerance_techs` of 0.7 because it was timing out with 0.05 - these changes were inconsequential to the features that were being checked in the unit tests.
