### PR TITLE
Fix validation to allow LoadProfileBoilerFuel .loads_mmbtu_per_hour

### DIFF
--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1530,7 +1530,7 @@ class ValidateNestedInput:
                         [[0] * self.input_dict['Scenario']['time_steps_per_hour'] for _ in range(8760)]).astype(list)))
                     self.defaults_inserted.append(['loads_mmbtu_per_hour', object_name_path])
                 # If a dictionary comes in with vaues and no doe reference name then use the electric load profile building type by default
-                if not no_values_given and real_values.get('doe_reference_name') is None:
+                if not no_values_given and real_values.get('doe_reference_name') is None and real_values.get('loads_mmbtu_per_hour') is None:
                     if self.input_dict['Scenario']['Site']['LoadProfile'].get('doe_reference_name') is not None:
                         self.update_attribute_value(object_name_path, number, 'doe_reference_name',
                                                 self.input_dict['Scenario']['Site']['LoadProfile'].get('doe_reference_name'))


### PR DESCRIPTION
Bug fix for inputs validation of heating load (`LoadProfileBoilerFuel`). The API was erroneously giving an `input_error` if a custom 8760 heating load (`LoadProfileBoilerFuel.loads_mmbtu_per_hour`) was supplied and the `doe_reference_name` for `LoadProfile` or `LoadProfileBoilerFuel` **not** supplied. We don't need `doe_reference_name` if the 8760 profile is supplied.

This PR addresses this [Pivotal Story](https://www.pivotaltracker.com/n/projects/1909317/stories/180319110). 
