### PR TITLE
Divbyzero fix

### DIFF
--- a/reo/process_results.py
+++ b/reo/process_results.py
@@ -534,7 +534,9 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
 
             # emissions reductions 
             self.nested_outputs["Scenario"]["Site"]["lifecycle_emissions_reduction_CO2_pct"] = self.results_dict.get("lifecycle_emissions_reduction_CO2_pct")
-            if self.results_dict.get("off_grid_flag") != True: 
+            emissions_diff = (self.results_dict.get("year_one_emissions_from_elec_grid_tCO2_bau") - self.results_dict.get("year_one_emissions_from_elec_grid_tCO2")  ) \
+                        +  (self.results_dict.get("year_one_emissions_from_fuelburn_tCO2_bau") - self.results_dict.get("year_one_emissions_from_fuelburn_tCO2") ) 
+            if (self.results_dict.get("off_grid_flag") != True and emissions_diff != 0.0): # if off-grid or bau and optimized emissions are the same, don't report breakeven cost
                 # breakeven cost of CO2 (for NPV = 0)
                 # first, remove climate costs from the output NPV, if they were previously included in LCC/NPV calcs:
                 npv_without_modeled_climate_costs = self.results_dict.get("npv")
@@ -542,14 +544,14 @@ def process_results(self, dfm_list, data, meta, saveToDB=True):
                     npv_without_modeled_climate_costs -= (self.results_dict.get("lifecycle_emissions_cost_CO2_bau") - self.results_dict.get("lifecycle_emissions_cost_CO2"))
                 # we want to calculate the breakeven  year 1 cost of CO2 (usd per tonne) that would yield an npv of 0, holding all other inputs constant
                 # (back-calculating using the equation for m[:Lifecycle_Emissions_Cost_CO2] in "add_lifecycle_emissions_calcs" in reopt_model.jl)
-                if npv_without_modeled_climate_costs >= 0: # if the system is cost effective (NPV > 0) without considering any cost of CO2, no cost of carbon 
-                    self.nested_outputs["Scenario"]["Site"]["breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2"] = 0
+                if npv_without_modeled_climate_costs >= 0: # if the system is cost effective (NPV >= 0) without considering any cost of CO2, no breakeven value is reported 
+                    self.nested_outputs["Scenario"]["Site"]["breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2"] = None
                 else:
                     self.nested_outputs["Scenario"]["Site"]["breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2"] = -1 * npv_without_modeled_climate_costs \
                         / ( self.results_dict.get("pwfs_emissions_cost_CO2_grid") * (self.results_dict.get("year_one_emissions_from_elec_grid_tCO2_bau") - self.results_dict.get("year_one_emissions_from_elec_grid_tCO2")  ) \
                         +  self.results_dict.get("pwfs_emissions_cost_CO2_onsite") * (self.results_dict.get("year_one_emissions_from_fuelburn_tCO2_bau") - self.results_dict.get("year_one_emissions_from_fuelburn_tCO2") ) )
             else:
-                self.nested_outputs["Scenario"]["Site"]["breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2"] = 0
+                self.nested_outputs["Scenario"]["Site"]["breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2"] = None
 
                 
             ## Renewable energy

--- a/reo/tests/test_re_emissions_constraints.py
+++ b/reo/tests/test_re_emissions_constraints.py
@@ -130,7 +130,7 @@ class REandEmissionsContraintTests(ResourceTestCaseMixin, TestCase):
             self.assertAlmostEquals(year_one_emissions_tCO2_out,yr1_total_emissions_calced_tCO2,places=-1)
             # Breakeven cost of emissions reductions 
             yr1_cost_ER_usd_per_tCO2_out = d['outputs']['Scenario']['Site']['breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2'] 
-            self.assertTrue(yr1_cost_ER_usd_per_tCO2_out>=0.0)
+            self.assertTrue(yr1_cost_ER_usd_per_tCO2_out is None or yr1_cost_ER_usd_per_tCO2_out>=0.0)
 
             ### test expected values for each scenario:                         
             if i ==0: # Scenario 1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix for scenarios in which emissions are equal in the BAU and Optimized cases (e.g. system is sized but not dispatched). These scenarios and off grid runs now report "None" for the output "breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2" 


### What is the current behavior?
(You can also link to an open issue here)
Div by Zero error. 


### What is the new behavior (if this is a feature change)?
These scenarios and off grid runs now report "None" for the output "breakeven_cost_of_emissions_reduction_us_dollars_per_tCO2" 


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No. 


### Other information:
