### PR TITLE
Fix double-counting CHP prod-based O&M cost

### DIFF
--- a/julia_src/reopt_model.jl
+++ b/julia_src/reopt_model.jl
@@ -124,18 +124,10 @@ function add_cost_expressions(m, p)
 	m[:TotalPerUnitSizeOMCosts] = @expression(m, p.two_party_factor * p.pwf_om *
 		sum( p.OMperUnitSize[t] * m[:dvSize][t] for t in p.Tech )
 	)
-    if !isempty(p.FuelBurningTechs) && isempty(p.HeatingTechs)
+    FuelBurnAndHeatingTechs = union(p.FuelBurningTechs, p.HeatingTechs)
+    if !isempty(FuelBurnAndHeatingTechs)
 		m[:TotalPerUnitProdOMCosts] = @expression(m, p.two_party_factor * p.pwf_om * p.TimeStepScaling * 
-			sum( p.OMcostPerUnitProd[t] * m[:dvRatedProduction][t,ts] for t in p.FuelBurningTechs, ts in p.TimeStep )
-		)
-    elseif !isempty(p.HeatingTechs) && isempty(p.FuelBurningTechs)
-		m[:TotalPerUnitProdOMCosts] = @expression(m, p.two_party_factor * p.pwf_om * p.TimeStepScaling *
-            sum( p.OMcostPerUnitProd[t] * m[:dvRatedProduction][t,ts] for t in p.HeatingTechs, ts in p.TimeStep )
-		)
-    elseif !isempty(p.HeatingTechs) && !isempty(p.FuelBurningTechs)
-		m[:TotalPerUnitProdOMCosts] = @expression(m, p.two_party_factor * p.pwf_om * p.TimeStepScaling *
-            (sum( p.OMcostPerUnitProd[t] * m[:dvRatedProduction][t,ts] for t in p.FuelBurningTechs, ts in p.TimeStep ) +
-            sum( p.OMcostPerUnitProd[t] * m[:dvRatedProduction][t,ts] for t in p.HeatingTechs, ts in p.TimeStep ))
+			sum( p.OMcostPerUnitProd[t] * m[:dvRatedProduction][t,ts] for t in FuelBurnAndHeatingTechs, ts in p.TimeStep )
 		)
     else
         m[:TotalPerUnitProdOMCosts] = @expression(m, 0.0)


### PR DESCRIPTION
Major CHP bug hot fix: CHP variable (production-based) O&M is being double-counted (twice as high as it should be). This change fixes that, and makes the reopt_model.jl code more concise.